### PR TITLE
1.02 Release

### DIFF
--- a/Touhou Launcher/MainForm.Designer.cs
+++ b/Touhou Launcher/MainForm.Designer.cs
@@ -210,6 +210,9 @@
             this.trayOpen = new System.Windows.Forms.ToolStripMenuItem();
             this.trayExit = new System.Windows.Forms.ToolStripMenuItem();
             this.trayIcon = new System.Windows.Forms.NotifyIcon(this.components);
+            this.btnHBM = new System.Windows.Forms.Button();
+            this.trayHBM = new System.Windows.Forms.ToolStripMenuItem();
+            this.chkHBM = new System.Windows.Forms.CheckBox();
             this.gameContextMenu.SuspendLayout();
             this.customContextMenu.SuspendLayout();
             this.customFolderContextMenu.SuspendLayout();
@@ -713,6 +716,7 @@
             this.miscRandomPanel.Controls.Add(this.chkISC);
             this.miscRandomPanel.Controls.Add(this.chkVD);
             this.miscRandomPanel.Controls.Add(this.chkGI);
+            this.miscRandomPanel.Controls.Add(this.chkHBM);
             this.miscRandomPanel.Location = new System.Drawing.Point(3, 16);
             this.miscRandomPanel.Margin = new System.Windows.Forms.Padding(0);
             this.miscRandomPanel.Name = "miscRandomPanel";
@@ -1547,6 +1551,7 @@
             this.miscLayoutPanel.Controls.Add(this.btnISC);
             this.miscLayoutPanel.Controls.Add(this.btnVD);
             this.miscLayoutPanel.Controls.Add(this.btnGI);
+            this.miscLayoutPanel.Controls.Add(this.btnHBM);
             this.miscLayoutPanel.Location = new System.Drawing.Point(3, 16);
             this.miscLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
             this.miscLayoutPanel.Name = "miscLayoutPanel";
@@ -2352,7 +2357,8 @@
             this.trayGFW,
             this.trayISC,
             this.trayVD,
-            this.trayGI});
+            this.trayGI,
+            this.trayHBM});
             this.trayOther.Name = "trayOther";
             this.trayOther.Size = new System.Drawing.Size(157, 22);
             this.trayOther.Text = "Other Games";
@@ -2449,6 +2455,46 @@
             this.trayIcon.Icon = global::Touhou_Launcher.Properties.Resources.thicon;
             this.trayIcon.Text = "Touhou Launcher";
             this.trayIcon.DoubleClick += new System.EventHandler(this.MainForm_Show);
+            // 
+            // btnHBM
+            // 
+            this.btnHBM.BackgroundImage = global::Touhou_Launcher.Properties.Resources.hbmg;
+            this.btnHBM.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btnHBM.ContextMenuStrip = this.gameContextMenu;
+            this.btnHBM.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btnHBM.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.btnHBM.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.btnHBM.Location = new System.Drawing.Point(255, 53);
+            this.btnHBM.Name = "btnHBM";
+            this.btnHBM.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
+            this.btnHBM.Size = new System.Drawing.Size(120, 44);
+            this.btnHBM.TabIndex = 6;
+            this.btnHBM.Text = "100th Black Market";
+            this.btnHBM.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btnHBM.UseVisualStyleBackColor = true;
+            this.btnHBM.Click += new System.EventHandler(this.btn_Click);
+            // 
+            // trayHBM
+            // 
+            this.trayHBM.Image = global::Touhou_Launcher.Properties.Resources.Icon_th185;
+            this.trayHBM.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayHBM.Name = "trayHBM";
+            this.trayHBM.Size = new System.Drawing.Size(203, 38);
+            this.trayHBM.Text = "100th Black Market";
+            this.trayHBM.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // chkHBM
+            // 
+            this.chkHBM.AutoSize = true;
+            this.chkHBM.Checked = true;
+            this.chkHBM.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkHBM.Location = new System.Drawing.Point(46, 26);
+            this.chkHBM.Name = "chkHBM";
+            this.chkHBM.Size = new System.Drawing.Size(60, 17);
+            this.chkHBM.TabIndex = 6;
+            this.chkHBM.Text = "100BM";
+            this.chkHBM.UseVisualStyleBackColor = true;
+            this.chkHBM.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
             // 
             // MainForm
             // 
@@ -2680,6 +2726,9 @@
         private System.Windows.Forms.CheckBox chkGI;
         private System.Windows.Forms.Button btnGI;
         private System.Windows.Forms.ToolStripMenuItem trayGI;
+        private System.Windows.Forms.Button btnHBM;
+        private System.Windows.Forms.ToolStripMenuItem trayHBM;
+        private System.Windows.Forms.CheckBox chkHBM;
     }
 }
 

--- a/Touhou Launcher/MainForm.Designer.cs
+++ b/Touhou Launcher/MainForm.Designer.cs
@@ -72,32 +72,28 @@
             this.label1 = new System.Windows.Forms.Label();
             this.settings = new System.Windows.Forms.TabPage();
             this.randomSettings = new System.Windows.Forms.GroupBox();
-            this.randomLabel = new System.Windows.Forms.Label();
-            this.randomNone = new System.Windows.Forms.Button();
-            this.randomAll = new System.Windows.Forms.Button();
-            this.otherRandom = new System.Windows.Forms.GroupBox();
-            this.miscRandomPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.spinoffRandom = new System.Windows.Forms.GroupBox();
+            this.spinoffRandomPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.chkStB = new System.Windows.Forms.CheckBox();
             this.chkDS = new System.Windows.Forms.CheckBox();
             this.chkGFW = new System.Windows.Forms.CheckBox();
             this.chkISC = new System.Windows.Forms.CheckBox();
             this.chkVD = new System.Windows.Forms.CheckBox();
-            this.chkGI = new System.Windows.Forms.CheckBox();
-            this.fightingRandom = new System.Windows.Forms.GroupBox();
-            this.fightingRandomPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.chkHBM = new System.Windows.Forms.CheckBox();
+            this.randomLabel = new System.Windows.Forms.Label();
+            this.randomNone = new System.Windows.Forms.Button();
+            this.randomAll = new System.Windows.Forms.Button();
+            this.tasofroRandom = new System.Windows.Forms.GroupBox();
+            this.tasofroRandomPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.chkIaMP = new System.Windows.Forms.CheckBox();
             this.chkSWR = new System.Windows.Forms.CheckBox();
             this.chkUoNL = new System.Windows.Forms.CheckBox();
             this.chkHM = new System.Windows.Forms.CheckBox();
             this.chkULiL = new System.Windows.Forms.CheckBox();
             this.chkAoCF = new System.Windows.Forms.CheckBox();
+            this.chkGI = new System.Windows.Forms.CheckBox();
             this.mainRandom = new System.Windows.Forms.GroupBox();
             this.mainRandomPanel = new System.Windows.Forms.FlowLayoutPanel();
-            this.chkHRtP = new System.Windows.Forms.CheckBox();
-            this.chkSoEW = new System.Windows.Forms.CheckBox();
-            this.chkPoDD = new System.Windows.Forms.CheckBox();
-            this.chkLLS = new System.Windows.Forms.CheckBox();
-            this.chkMS = new System.Windows.Forms.CheckBox();
             this.chkEoSD = new System.Windows.Forms.CheckBox();
             this.chkPCB = new System.Windows.Forms.CheckBox();
             this.chkIN = new System.Windows.Forms.CheckBox();
@@ -111,6 +107,13 @@
             this.chkHSiFS = new System.Windows.Forms.CheckBox();
             this.chkWBaWC = new System.Windows.Forms.CheckBox();
             this.chkUM = new System.Windows.Forms.CheckBox();
+            this.pc98Random = new System.Windows.Forms.GroupBox();
+            this.pc98RandomPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.chkHRtP = new System.Windows.Forms.CheckBox();
+            this.chkSoEW = new System.Windows.Forms.CheckBox();
+            this.chkPoDD = new System.Windows.Forms.CheckBox();
+            this.chkLLS = new System.Windows.Forms.CheckBox();
+            this.chkMS = new System.Windows.Forms.CheckBox();
             this.launcherSettings = new System.Windows.Forms.GroupBox();
             this.crapResetStartingRepo = new System.Windows.Forms.Button();
             this.crapStartingRepo = new System.Windows.Forms.TextBox();
@@ -139,22 +142,23 @@
             this.customTree = new System.Windows.Forms.TreeView();
             this.mainControl = new System.Windows.Forms.TabControl();
             this.games = new System.Windows.Forms.TabPage();
-            this.otherGroup = new System.Windows.Forms.GroupBox();
-            this.miscLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.spinoffGroup = new System.Windows.Forms.GroupBox();
+            this.spinoffLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.btnStB = new System.Windows.Forms.Button();
             this.btnDS = new System.Windows.Forms.Button();
             this.btnGFW = new System.Windows.Forms.Button();
             this.btnISC = new System.Windows.Forms.Button();
             this.btnVD = new System.Windows.Forms.Button();
-            this.btnGI = new System.Windows.Forms.Button();
-            this.fightingGroup = new System.Windows.Forms.GroupBox();
-            this.fightingLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.btnHBM = new System.Windows.Forms.Button();
+            this.tasofroGroup = new System.Windows.Forms.GroupBox();
+            this.tasofroLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.btnIaMP = new System.Windows.Forms.Button();
             this.btnSWR = new System.Windows.Forms.Button();
             this.btnUoNL = new System.Windows.Forms.Button();
             this.btnHM = new System.Windows.Forms.Button();
             this.btnULiL = new System.Windows.Forms.Button();
             this.btnAoCF = new System.Windows.Forms.Button();
+            this.btnGI = new System.Windows.Forms.Button();
             this.mainGroup = new System.Windows.Forms.GroupBox();
             this.mainLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.btnEoSD = new System.Windows.Forms.Button();
@@ -170,13 +174,16 @@
             this.btnHSiFS = new System.Windows.Forms.Button();
             this.btnWBaWC = new System.Windows.Forms.Button();
             this.btnUM = new System.Windows.Forms.Button();
+            this.pc98Group = new System.Windows.Forms.GroupBox();
+            this.pc98LayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.trayMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.trayMain = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayPC98 = new System.Windows.Forms.ToolStripMenuItem();
             this.trayHRtP = new System.Windows.Forms.ToolStripMenuItem();
             this.traySoEW = new System.Windows.Forms.ToolStripMenuItem();
             this.trayPoDD = new System.Windows.Forms.ToolStripMenuItem();
             this.trayLLS = new System.Windows.Forms.ToolStripMenuItem();
             this.trayMS = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayMain = new System.Windows.Forms.ToolStripMenuItem();
             this.trayEoSD = new System.Windows.Forms.ToolStripMenuItem();
             this.trayPCB = new System.Windows.Forms.ToolStripMenuItem();
             this.trayIN = new System.Windows.Forms.ToolStripMenuItem();
@@ -190,19 +197,20 @@
             this.trayHSiFS = new System.Windows.Forms.ToolStripMenuItem();
             this.trayWBaWC = new System.Windows.Forms.ToolStripMenuItem();
             this.trayUM = new System.Windows.Forms.ToolStripMenuItem();
-            this.trayFighting = new System.Windows.Forms.ToolStripMenuItem();
+            this.traySpinoff = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayStB = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayDS = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayGFW = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayISC = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayVD = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayHBM = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayTasofro = new System.Windows.Forms.ToolStripMenuItem();
             this.trayIaMP = new System.Windows.Forms.ToolStripMenuItem();
             this.traySWR = new System.Windows.Forms.ToolStripMenuItem();
             this.trayUoNL = new System.Windows.Forms.ToolStripMenuItem();
             this.trayHM = new System.Windows.Forms.ToolStripMenuItem();
             this.trayULiL = new System.Windows.Forms.ToolStripMenuItem();
             this.trayAoCF = new System.Windows.Forms.ToolStripMenuItem();
-            this.trayOther = new System.Windows.Forms.ToolStripMenuItem();
-            this.trayStB = new System.Windows.Forms.ToolStripMenuItem();
-            this.trayDS = new System.Windows.Forms.ToolStripMenuItem();
-            this.trayGFW = new System.Windows.Forms.ToolStripMenuItem();
-            this.trayISC = new System.Windows.Forms.ToolStripMenuItem();
-            this.trayVD = new System.Windows.Forms.ToolStripMenuItem();
             this.trayGI = new System.Windows.Forms.ToolStripMenuItem();
             this.trayCustom = new System.Windows.Forms.ToolStripMenuItem();
             this.trayRandom = new System.Windows.Forms.ToolStripMenuItem();
@@ -210,33 +218,34 @@
             this.trayOpen = new System.Windows.Forms.ToolStripMenuItem();
             this.trayExit = new System.Windows.Forms.ToolStripMenuItem();
             this.trayIcon = new System.Windows.Forms.NotifyIcon(this.components);
-            this.btnHBM = new System.Windows.Forms.Button();
-            this.trayHBM = new System.Windows.Forms.ToolStripMenuItem();
-            this.chkHBM = new System.Windows.Forms.CheckBox();
             this.gameContextMenu.SuspendLayout();
             this.customContextMenu.SuspendLayout();
             this.customFolderContextMenu.SuspendLayout();
             this.info.SuspendLayout();
             this.settings.SuspendLayout();
             this.randomSettings.SuspendLayout();
-            this.otherRandom.SuspendLayout();
-            this.miscRandomPanel.SuspendLayout();
-            this.fightingRandom.SuspendLayout();
-            this.fightingRandomPanel.SuspendLayout();
+            this.spinoffRandom.SuspendLayout();
+            this.spinoffRandomPanel.SuspendLayout();
+            this.tasofroRandom.SuspendLayout();
+            this.tasofroRandomPanel.SuspendLayout();
             this.mainRandom.SuspendLayout();
             this.mainRandomPanel.SuspendLayout();
+            this.pc98Random.SuspendLayout();
+            this.pc98RandomPanel.SuspendLayout();
             this.launcherSettings.SuspendLayout();
             this.replays.SuspendLayout();
             this.replayPanel.SuspendLayout();
             this.customGames.SuspendLayout();
             this.mainControl.SuspendLayout();
             this.games.SuspendLayout();
-            this.otherGroup.SuspendLayout();
-            this.miscLayoutPanel.SuspendLayout();
-            this.fightingGroup.SuspendLayout();
-            this.fightingLayoutPanel.SuspendLayout();
+            this.spinoffGroup.SuspendLayout();
+            this.spinoffLayoutPanel.SuspendLayout();
+            this.tasofroGroup.SuspendLayout();
+            this.tasofroLayoutPanel.SuspendLayout();
             this.mainGroup.SuspendLayout();
             this.mainLayoutPanel.SuspendLayout();
+            this.pc98Group.SuspendLayout();
+            this.pc98LayoutPanel.SuspendLayout();
             this.trayMenu.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -486,7 +495,7 @@
             this.btnSoEW.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnSoEW.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnSoEW.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnSoEW.Location = new System.Drawing.Point(129, 3);
+            this.btnSoEW.Location = new System.Drawing.Point(3, 53);
             this.btnSoEW.Name = "btnSoEW";
             this.btnSoEW.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnSoEW.Size = new System.Drawing.Size(120, 44);
@@ -504,11 +513,11 @@
             this.btnRandom.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnRandom.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnRandom.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnRandom.Location = new System.Drawing.Point(204, 538);
+            this.btnRandom.Location = new System.Drawing.Point(208, 510);
             this.btnRandom.Name = "btnRandom";
             this.btnRandom.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnRandom.Size = new System.Drawing.Size(120, 44);
-            this.btnRandom.TabIndex = 4;
+            this.btnRandom.TabIndex = 5;
             this.btnRandom.Text = "Random";
             this.btnRandom.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnRandom.UseVisualStyleBackColor = true;
@@ -522,7 +531,7 @@
             this.btnPoDD.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnPoDD.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnPoDD.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnPoDD.Location = new System.Drawing.Point(255, 3);
+            this.btnPoDD.Location = new System.Drawing.Point(3, 103);
             this.btnPoDD.Name = "btnPoDD";
             this.btnPoDD.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnPoDD.Size = new System.Drawing.Size(120, 44);
@@ -540,7 +549,7 @@
             this.btnLLS.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnLLS.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnLLS.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnLLS.Location = new System.Drawing.Point(381, 3);
+            this.btnLLS.Location = new System.Drawing.Point(3, 153);
             this.btnLLS.Name = "btnLLS";
             this.btnLLS.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnLLS.Size = new System.Drawing.Size(120, 44);
@@ -558,7 +567,7 @@
             this.btnMS.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnMS.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnMS.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnMS.Location = new System.Drawing.Point(3, 53);
+            this.btnMS.Location = new System.Drawing.Point(3, 203);
             this.btnMS.Name = "btnMS";
             this.btnMS.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnMS.Size = new System.Drawing.Size(120, 44);
@@ -579,7 +588,7 @@
             this.info.Location = new System.Drawing.Point(4, 22);
             this.info.Name = "info";
             this.info.Padding = new System.Windows.Forms.Padding(3);
-            this.info.Size = new System.Drawing.Size(527, 585);
+            this.info.Size = new System.Drawing.Size(537, 555);
             this.info.TabIndex = 5;
             this.info.Text = "Info";
             // 
@@ -640,7 +649,7 @@
             this.settings.Location = new System.Drawing.Point(4, 22);
             this.settings.Name = "settings";
             this.settings.Padding = new System.Windows.Forms.Padding(3);
-            this.settings.Size = new System.Drawing.Size(527, 585);
+            this.settings.Size = new System.Drawing.Size(537, 555);
             this.settings.TabIndex = 4;
             this.settings.Text = "Settings";
             // 
@@ -648,80 +657,49 @@
             // 
             this.randomSettings.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.randomSettings.Controls.Add(this.spinoffRandom);
             this.randomSettings.Controls.Add(this.randomLabel);
             this.randomSettings.Controls.Add(this.randomNone);
             this.randomSettings.Controls.Add(this.randomAll);
-            this.randomSettings.Controls.Add(this.otherRandom);
-            this.randomSettings.Controls.Add(this.fightingRandom);
+            this.randomSettings.Controls.Add(this.tasofroRandom);
             this.randomSettings.Controls.Add(this.mainRandom);
+            this.randomSettings.Controls.Add(this.pc98Random);
             this.randomSettings.Location = new System.Drawing.Point(214, 8);
             this.randomSettings.Name = "randomSettings";
-            this.randomSettings.Size = new System.Drawing.Size(307, 370);
+            this.randomSettings.Size = new System.Drawing.Size(317, 370);
             this.randomSettings.TabIndex = 2;
             this.randomSettings.TabStop = false;
             this.randomSettings.Text = "Random Game Settings";
             // 
-            // randomLabel
+            // spinoffRandom
             // 
-            this.randomLabel.Anchor = System.Windows.Forms.AnchorStyles.Top;
-            this.randomLabel.Location = new System.Drawing.Point(48, 16);
-            this.randomLabel.Name = "randomLabel";
-            this.randomLabel.Size = new System.Drawing.Size(211, 29);
-            this.randomLabel.TabIndex = 4;
-            this.randomLabel.Text = "Games that will be included in the\r\nrandom game option:";
-            this.randomLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // randomNone
-            // 
-            this.randomNone.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.randomNone.Location = new System.Drawing.Point(211, 49);
-            this.randomNone.Name = "randomNone";
-            this.randomNone.Size = new System.Drawing.Size(90, 25);
-            this.randomNone.TabIndex = 1;
-            this.randomNone.Text = "Select None";
-            this.randomNone.UseVisualStyleBackColor = true;
-            this.randomNone.Click += new System.EventHandler(this.randomNone_Click);
-            // 
-            // randomAll
-            // 
-            this.randomAll.Location = new System.Drawing.Point(6, 49);
-            this.randomAll.Name = "randomAll";
-            this.randomAll.Size = new System.Drawing.Size(90, 25);
-            this.randomAll.TabIndex = 0;
-            this.randomAll.Text = "Select All";
-            this.randomAll.UseVisualStyleBackColor = true;
-            this.randomAll.Click += new System.EventHandler(this.randomAll_Click);
-            // 
-            // otherRandom
-            // 
-            this.otherRandom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.spinoffRandom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.otherRandom.Controls.Add(this.miscRandomPanel);
-            this.otherRandom.Location = new System.Drawing.Point(6, 298);
-            this.otherRandom.Name = "otherRandom";
-            this.otherRandom.Size = new System.Drawing.Size(295, 66);
-            this.otherRandom.TabIndex = 4;
-            this.otherRandom.TabStop = false;
-            this.otherRandom.Text = "Other Games";
+            this.spinoffRandom.Controls.Add(this.spinoffRandomPanel);
+            this.spinoffRandom.Location = new System.Drawing.Point(6, 224);
+            this.spinoffRandom.Name = "spinoffRandom";
+            this.spinoffRandom.Size = new System.Drawing.Size(305, 68);
+            this.spinoffRandom.TabIndex = 4;
+            this.spinoffRandom.TabStop = false;
+            this.spinoffRandom.Text = "Spinoffs";
             // 
-            // miscRandomPanel
+            // spinoffRandomPanel
             // 
-            this.miscRandomPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.spinoffRandomPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.miscRandomPanel.AutoScroll = true;
-            this.miscRandomPanel.Controls.Add(this.chkStB);
-            this.miscRandomPanel.Controls.Add(this.chkDS);
-            this.miscRandomPanel.Controls.Add(this.chkGFW);
-            this.miscRandomPanel.Controls.Add(this.chkISC);
-            this.miscRandomPanel.Controls.Add(this.chkVD);
-            this.miscRandomPanel.Controls.Add(this.chkGI);
-            this.miscRandomPanel.Controls.Add(this.chkHBM);
-            this.miscRandomPanel.Location = new System.Drawing.Point(3, 16);
-            this.miscRandomPanel.Margin = new System.Windows.Forms.Padding(0);
-            this.miscRandomPanel.Name = "miscRandomPanel";
-            this.miscRandomPanel.Size = new System.Drawing.Size(289, 47);
-            this.miscRandomPanel.TabIndex = 1;
+            this.spinoffRandomPanel.AutoScroll = true;
+            this.spinoffRandomPanel.Controls.Add(this.chkStB);
+            this.spinoffRandomPanel.Controls.Add(this.chkDS);
+            this.spinoffRandomPanel.Controls.Add(this.chkGFW);
+            this.spinoffRandomPanel.Controls.Add(this.chkISC);
+            this.spinoffRandomPanel.Controls.Add(this.chkVD);
+            this.spinoffRandomPanel.Controls.Add(this.chkHBM);
+            this.spinoffRandomPanel.Location = new System.Drawing.Point(3, 16);
+            this.spinoffRandomPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.spinoffRandomPanel.Name = "spinoffRandomPanel";
+            this.spinoffRandomPanel.Size = new System.Drawing.Size(299, 49);
+            this.spinoffRandomPanel.TabIndex = 1;
             // 
             // chkStB
             // 
@@ -788,48 +766,80 @@
             this.chkVD.UseVisualStyleBackColor = true;
             this.chkVD.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
             // 
-            // chkGI
+            // chkHBM
             // 
-            this.chkGI.AutoSize = true;
-            this.chkGI.Checked = true;
-            this.chkGI.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkGI.Location = new System.Drawing.Point(3, 26);
-            this.chkGI.Name = "chkGI";
-            this.chkGI.Size = new System.Drawing.Size(37, 17);
-            this.chkGI.TabIndex = 5;
-            this.chkGI.Text = "GI";
-            this.chkGI.UseVisualStyleBackColor = true;
-            this.chkGI.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            this.chkHBM.AutoSize = true;
+            this.chkHBM.Checked = true;
+            this.chkHBM.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkHBM.Location = new System.Drawing.Point(3, 26);
+            this.chkHBM.Name = "chkHBM";
+            this.chkHBM.Size = new System.Drawing.Size(60, 17);
+            this.chkHBM.TabIndex = 18;
+            this.chkHBM.Text = "100BM";
+            this.chkHBM.UseVisualStyleBackColor = true;
+            this.chkHBM.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
             // 
-            // fightingRandom
+            // randomLabel
             // 
-            this.fightingRandom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.randomLabel.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.randomLabel.Location = new System.Drawing.Point(53, 16);
+            this.randomLabel.Name = "randomLabel";
+            this.randomLabel.Size = new System.Drawing.Size(211, 29);
+            this.randomLabel.TabIndex = 4;
+            this.randomLabel.Text = "Games that will be included in the\r\nrandom game option:";
+            this.randomLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // randomNone
+            // 
+            this.randomNone.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.randomNone.Location = new System.Drawing.Point(221, 49);
+            this.randomNone.Name = "randomNone";
+            this.randomNone.Size = new System.Drawing.Size(90, 25);
+            this.randomNone.TabIndex = 1;
+            this.randomNone.Text = "Select None";
+            this.randomNone.UseVisualStyleBackColor = true;
+            this.randomNone.Click += new System.EventHandler(this.randomNone_Click);
+            // 
+            // randomAll
+            // 
+            this.randomAll.Location = new System.Drawing.Point(6, 49);
+            this.randomAll.Name = "randomAll";
+            this.randomAll.Size = new System.Drawing.Size(90, 25);
+            this.randomAll.TabIndex = 0;
+            this.randomAll.Text = "Select All";
+            this.randomAll.UseVisualStyleBackColor = true;
+            this.randomAll.Click += new System.EventHandler(this.randomAll_Click);
+            // 
+            // tasofroRandom
+            // 
+            this.tasofroRandom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.fightingRandom.Controls.Add(this.fightingRandomPanel);
-            this.fightingRandom.Location = new System.Drawing.Point(6, 219);
-            this.fightingRandom.Name = "fightingRandom";
-            this.fightingRandom.Size = new System.Drawing.Size(295, 68);
-            this.fightingRandom.TabIndex = 3;
-            this.fightingRandom.TabStop = false;
-            this.fightingRandom.Text = "Fighting Games";
+            this.tasofroRandom.Controls.Add(this.tasofroRandomPanel);
+            this.tasofroRandom.Location = new System.Drawing.Point(6, 298);
+            this.tasofroRandom.Name = "tasofroRandom";
+            this.tasofroRandom.Size = new System.Drawing.Size(305, 66);
+            this.tasofroRandom.TabIndex = 5;
+            this.tasofroRandom.TabStop = false;
+            this.tasofroRandom.Text = "Twilight Frontier Games";
             // 
-            // fightingRandomPanel
+            // tasofroRandomPanel
             // 
-            this.fightingRandomPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.tasofroRandomPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.fightingRandomPanel.AutoScroll = true;
-            this.fightingRandomPanel.Controls.Add(this.chkIaMP);
-            this.fightingRandomPanel.Controls.Add(this.chkSWR);
-            this.fightingRandomPanel.Controls.Add(this.chkUoNL);
-            this.fightingRandomPanel.Controls.Add(this.chkHM);
-            this.fightingRandomPanel.Controls.Add(this.chkULiL);
-            this.fightingRandomPanel.Controls.Add(this.chkAoCF);
-            this.fightingRandomPanel.Location = new System.Drawing.Point(3, 16);
-            this.fightingRandomPanel.Margin = new System.Windows.Forms.Padding(0);
-            this.fightingRandomPanel.Name = "fightingRandomPanel";
-            this.fightingRandomPanel.Size = new System.Drawing.Size(289, 49);
-            this.fightingRandomPanel.TabIndex = 1;
+            this.tasofroRandomPanel.AutoScroll = true;
+            this.tasofroRandomPanel.Controls.Add(this.chkIaMP);
+            this.tasofroRandomPanel.Controls.Add(this.chkSWR);
+            this.tasofroRandomPanel.Controls.Add(this.chkUoNL);
+            this.tasofroRandomPanel.Controls.Add(this.chkHM);
+            this.tasofroRandomPanel.Controls.Add(this.chkULiL);
+            this.tasofroRandomPanel.Controls.Add(this.chkAoCF);
+            this.tasofroRandomPanel.Controls.Add(this.chkGI);
+            this.tasofroRandomPanel.Location = new System.Drawing.Point(3, 16);
+            this.tasofroRandomPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.tasofroRandomPanel.Name = "tasofroRandomPanel";
+            this.tasofroRandomPanel.Size = new System.Drawing.Size(299, 47);
+            this.tasofroRandomPanel.TabIndex = 1;
             // 
             // chkIaMP
             // 
@@ -909,15 +919,28 @@
             this.chkAoCF.UseVisualStyleBackColor = true;
             this.chkAoCF.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
             // 
+            // chkGI
+            // 
+            this.chkGI.AutoSize = true;
+            this.chkGI.Checked = true;
+            this.chkGI.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkGI.Location = new System.Drawing.Point(115, 26);
+            this.chkGI.Name = "chkGI";
+            this.chkGI.Size = new System.Drawing.Size(37, 17);
+            this.chkGI.TabIndex = 6;
+            this.chkGI.Text = "GI";
+            this.chkGI.UseVisualStyleBackColor = true;
+            this.chkGI.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
             // mainRandom
             // 
             this.mainRandom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.mainRandom.Controls.Add(this.mainRandomPanel);
-            this.mainRandom.Location = new System.Drawing.Point(6, 80);
+            this.mainRandom.Location = new System.Drawing.Point(6, 128);
             this.mainRandom.Name = "mainRandom";
-            this.mainRandom.Size = new System.Drawing.Size(295, 133);
-            this.mainRandom.TabIndex = 2;
+            this.mainRandom.Size = new System.Drawing.Size(305, 90);
+            this.mainRandom.TabIndex = 3;
             this.mainRandom.TabStop = false;
             this.mainRandom.Text = "Main Games";
             // 
@@ -927,11 +950,6 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.mainRandomPanel.AutoScroll = true;
-            this.mainRandomPanel.Controls.Add(this.chkHRtP);
-            this.mainRandomPanel.Controls.Add(this.chkSoEW);
-            this.mainRandomPanel.Controls.Add(this.chkPoDD);
-            this.mainRandomPanel.Controls.Add(this.chkLLS);
-            this.mainRandomPanel.Controls.Add(this.chkMS);
             this.mainRandomPanel.Controls.Add(this.chkEoSD);
             this.mainRandomPanel.Controls.Add(this.chkPCB);
             this.mainRandomPanel.Controls.Add(this.chkIN);
@@ -948,8 +966,206 @@
             this.mainRandomPanel.Location = new System.Drawing.Point(3, 16);
             this.mainRandomPanel.Margin = new System.Windows.Forms.Padding(0);
             this.mainRandomPanel.Name = "mainRandomPanel";
-            this.mainRandomPanel.Size = new System.Drawing.Size(289, 114);
-            this.mainRandomPanel.TabIndex = 0;
+            this.mainRandomPanel.Size = new System.Drawing.Size(299, 71);
+            this.mainRandomPanel.TabIndex = 1;
+            // 
+            // chkEoSD
+            // 
+            this.chkEoSD.AutoSize = true;
+            this.chkEoSD.Checked = true;
+            this.chkEoSD.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkEoSD.Location = new System.Drawing.Point(3, 3);
+            this.chkEoSD.Name = "chkEoSD";
+            this.chkEoSD.Size = new System.Drawing.Size(54, 17);
+            this.chkEoSD.TabIndex = 0;
+            this.chkEoSD.Text = "EoSD";
+            this.chkEoSD.UseVisualStyleBackColor = true;
+            this.chkEoSD.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkPCB
+            // 
+            this.chkPCB.AutoSize = true;
+            this.chkPCB.Checked = true;
+            this.chkPCB.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkPCB.Location = new System.Drawing.Point(63, 3);
+            this.chkPCB.Name = "chkPCB";
+            this.chkPCB.Size = new System.Drawing.Size(47, 17);
+            this.chkPCB.TabIndex = 1;
+            this.chkPCB.Text = "PCB";
+            this.chkPCB.UseVisualStyleBackColor = true;
+            this.chkPCB.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkIN
+            // 
+            this.chkIN.AutoSize = true;
+            this.chkIN.Checked = true;
+            this.chkIN.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkIN.Location = new System.Drawing.Point(116, 3);
+            this.chkIN.Name = "chkIN";
+            this.chkIN.Size = new System.Drawing.Size(37, 17);
+            this.chkIN.TabIndex = 2;
+            this.chkIN.Text = "IN";
+            this.chkIN.UseVisualStyleBackColor = true;
+            this.chkIN.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkPoFV
+            // 
+            this.chkPoFV.AutoSize = true;
+            this.chkPoFV.Checked = true;
+            this.chkPoFV.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkPoFV.Location = new System.Drawing.Point(159, 3);
+            this.chkPoFV.Name = "chkPoFV";
+            this.chkPoFV.Size = new System.Drawing.Size(52, 17);
+            this.chkPoFV.TabIndex = 3;
+            this.chkPoFV.Text = "PoFV";
+            this.chkPoFV.UseVisualStyleBackColor = true;
+            this.chkPoFV.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkMoF
+            // 
+            this.chkMoF.AutoSize = true;
+            this.chkMoF.Checked = true;
+            this.chkMoF.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkMoF.Location = new System.Drawing.Point(217, 3);
+            this.chkMoF.Name = "chkMoF";
+            this.chkMoF.Size = new System.Drawing.Size(47, 17);
+            this.chkMoF.TabIndex = 4;
+            this.chkMoF.Text = "MoF";
+            this.chkMoF.UseVisualStyleBackColor = true;
+            this.chkMoF.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkSA
+            // 
+            this.chkSA.AutoSize = true;
+            this.chkSA.Checked = true;
+            this.chkSA.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkSA.Location = new System.Drawing.Point(3, 26);
+            this.chkSA.Name = "chkSA";
+            this.chkSA.Size = new System.Drawing.Size(40, 17);
+            this.chkSA.TabIndex = 5;
+            this.chkSA.Text = "SA";
+            this.chkSA.UseVisualStyleBackColor = true;
+            this.chkSA.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkUFO
+            // 
+            this.chkUFO.AutoSize = true;
+            this.chkUFO.Checked = true;
+            this.chkUFO.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkUFO.Location = new System.Drawing.Point(49, 26);
+            this.chkUFO.Name = "chkUFO";
+            this.chkUFO.Size = new System.Drawing.Size(48, 17);
+            this.chkUFO.TabIndex = 6;
+            this.chkUFO.Text = "UFO";
+            this.chkUFO.UseVisualStyleBackColor = true;
+            this.chkUFO.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkTD
+            // 
+            this.chkTD.AutoSize = true;
+            this.chkTD.Checked = true;
+            this.chkTD.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkTD.Location = new System.Drawing.Point(103, 26);
+            this.chkTD.Name = "chkTD";
+            this.chkTD.Size = new System.Drawing.Size(41, 17);
+            this.chkTD.TabIndex = 7;
+            this.chkTD.Text = "TD";
+            this.chkTD.UseVisualStyleBackColor = true;
+            this.chkTD.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkDDC
+            // 
+            this.chkDDC.AutoSize = true;
+            this.chkDDC.Checked = true;
+            this.chkDDC.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkDDC.Location = new System.Drawing.Point(150, 26);
+            this.chkDDC.Name = "chkDDC";
+            this.chkDDC.Size = new System.Drawing.Size(49, 17);
+            this.chkDDC.TabIndex = 8;
+            this.chkDDC.Text = "DDC";
+            this.chkDDC.UseVisualStyleBackColor = true;
+            this.chkDDC.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkLoLK
+            // 
+            this.chkLoLK.AutoSize = true;
+            this.chkLoLK.Checked = true;
+            this.chkLoLK.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkLoLK.Location = new System.Drawing.Point(205, 26);
+            this.chkLoLK.Name = "chkLoLK";
+            this.chkLoLK.Size = new System.Drawing.Size(51, 17);
+            this.chkLoLK.TabIndex = 9;
+            this.chkLoLK.Text = "LoLK";
+            this.chkLoLK.UseVisualStyleBackColor = true;
+            this.chkLoLK.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkHSiFS
+            // 
+            this.chkHSiFS.AutoSize = true;
+            this.chkHSiFS.Checked = true;
+            this.chkHSiFS.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkHSiFS.Location = new System.Drawing.Point(3, 49);
+            this.chkHSiFS.Name = "chkHSiFS";
+            this.chkHSiFS.Size = new System.Drawing.Size(56, 17);
+            this.chkHSiFS.TabIndex = 10;
+            this.chkHSiFS.Text = "HSiFS";
+            this.chkHSiFS.UseVisualStyleBackColor = true;
+            this.chkHSiFS.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkWBaWC
+            // 
+            this.chkWBaWC.AutoSize = true;
+            this.chkWBaWC.Checked = true;
+            this.chkWBaWC.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkWBaWC.Location = new System.Drawing.Point(65, 49);
+            this.chkWBaWC.Name = "chkWBaWC";
+            this.chkWBaWC.Size = new System.Drawing.Size(68, 17);
+            this.chkWBaWC.TabIndex = 11;
+            this.chkWBaWC.Text = "WBaWC";
+            this.chkWBaWC.UseVisualStyleBackColor = true;
+            this.chkWBaWC.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkUM
+            // 
+            this.chkUM.AutoSize = true;
+            this.chkUM.Checked = true;
+            this.chkUM.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkUM.Location = new System.Drawing.Point(139, 49);
+            this.chkUM.Name = "chkUM";
+            this.chkUM.Size = new System.Drawing.Size(43, 17);
+            this.chkUM.TabIndex = 12;
+            this.chkUM.Text = "UM";
+            this.chkUM.UseVisualStyleBackColor = true;
+            this.chkUM.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // pc98Random
+            // 
+            this.pc98Random.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pc98Random.Controls.Add(this.pc98RandomPanel);
+            this.pc98Random.Location = new System.Drawing.Point(6, 80);
+            this.pc98Random.Name = "pc98Random";
+            this.pc98Random.Size = new System.Drawing.Size(305, 42);
+            this.pc98Random.TabIndex = 2;
+            this.pc98Random.TabStop = false;
+            this.pc98Random.Text = "PC-98 Games";
+            // 
+            // pc98RandomPanel
+            // 
+            this.pc98RandomPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pc98RandomPanel.AutoScroll = true;
+            this.pc98RandomPanel.Controls.Add(this.chkHRtP);
+            this.pc98RandomPanel.Controls.Add(this.chkSoEW);
+            this.pc98RandomPanel.Controls.Add(this.chkPoDD);
+            this.pc98RandomPanel.Controls.Add(this.chkLLS);
+            this.pc98RandomPanel.Controls.Add(this.chkMS);
+            this.pc98RandomPanel.Location = new System.Drawing.Point(3, 16);
+            this.pc98RandomPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.pc98RandomPanel.Name = "pc98RandomPanel";
+            this.pc98RandomPanel.Size = new System.Drawing.Size(299, 23);
+            this.pc98RandomPanel.TabIndex = 0;
             // 
             // chkHRtP
             // 
@@ -1015,175 +1231,6 @@
             this.chkMS.Text = "MS";
             this.chkMS.UseVisualStyleBackColor = true;
             this.chkMS.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkEoSD
-            // 
-            this.chkEoSD.AutoSize = true;
-            this.chkEoSD.Checked = true;
-            this.chkEoSD.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkEoSD.Location = new System.Drawing.Point(3, 26);
-            this.chkEoSD.Name = "chkEoSD";
-            this.chkEoSD.Size = new System.Drawing.Size(54, 17);
-            this.chkEoSD.TabIndex = 5;
-            this.chkEoSD.Text = "EoSD";
-            this.chkEoSD.UseVisualStyleBackColor = true;
-            this.chkEoSD.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkPCB
-            // 
-            this.chkPCB.AutoSize = true;
-            this.chkPCB.Checked = true;
-            this.chkPCB.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkPCB.Location = new System.Drawing.Point(63, 26);
-            this.chkPCB.Name = "chkPCB";
-            this.chkPCB.Size = new System.Drawing.Size(47, 17);
-            this.chkPCB.TabIndex = 6;
-            this.chkPCB.Text = "PCB";
-            this.chkPCB.UseVisualStyleBackColor = true;
-            this.chkPCB.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkIN
-            // 
-            this.chkIN.AutoSize = true;
-            this.chkIN.Checked = true;
-            this.chkIN.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkIN.Location = new System.Drawing.Point(116, 26);
-            this.chkIN.Name = "chkIN";
-            this.chkIN.Size = new System.Drawing.Size(37, 17);
-            this.chkIN.TabIndex = 7;
-            this.chkIN.Text = "IN";
-            this.chkIN.UseVisualStyleBackColor = true;
-            this.chkIN.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkPoFV
-            // 
-            this.chkPoFV.AutoSize = true;
-            this.chkPoFV.Checked = true;
-            this.chkPoFV.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkPoFV.Location = new System.Drawing.Point(159, 26);
-            this.chkPoFV.Name = "chkPoFV";
-            this.chkPoFV.Size = new System.Drawing.Size(52, 17);
-            this.chkPoFV.TabIndex = 8;
-            this.chkPoFV.Text = "PoFV";
-            this.chkPoFV.UseVisualStyleBackColor = true;
-            this.chkPoFV.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkMoF
-            // 
-            this.chkMoF.AutoSize = true;
-            this.chkMoF.Checked = true;
-            this.chkMoF.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkMoF.Location = new System.Drawing.Point(217, 26);
-            this.chkMoF.Name = "chkMoF";
-            this.chkMoF.Size = new System.Drawing.Size(47, 17);
-            this.chkMoF.TabIndex = 9;
-            this.chkMoF.Text = "MoF";
-            this.chkMoF.UseVisualStyleBackColor = true;
-            this.chkMoF.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkSA
-            // 
-            this.chkSA.AutoSize = true;
-            this.chkSA.Checked = true;
-            this.chkSA.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkSA.Location = new System.Drawing.Point(3, 49);
-            this.chkSA.Name = "chkSA";
-            this.chkSA.Size = new System.Drawing.Size(40, 17);
-            this.chkSA.TabIndex = 10;
-            this.chkSA.Text = "SA";
-            this.chkSA.UseVisualStyleBackColor = true;
-            this.chkSA.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkUFO
-            // 
-            this.chkUFO.AutoSize = true;
-            this.chkUFO.Checked = true;
-            this.chkUFO.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkUFO.Location = new System.Drawing.Point(49, 49);
-            this.chkUFO.Name = "chkUFO";
-            this.chkUFO.Size = new System.Drawing.Size(48, 17);
-            this.chkUFO.TabIndex = 11;
-            this.chkUFO.Text = "UFO";
-            this.chkUFO.UseVisualStyleBackColor = true;
-            this.chkUFO.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkTD
-            // 
-            this.chkTD.AutoSize = true;
-            this.chkTD.Checked = true;
-            this.chkTD.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkTD.Location = new System.Drawing.Point(103, 49);
-            this.chkTD.Name = "chkTD";
-            this.chkTD.Size = new System.Drawing.Size(41, 17);
-            this.chkTD.TabIndex = 12;
-            this.chkTD.Text = "TD";
-            this.chkTD.UseVisualStyleBackColor = true;
-            this.chkTD.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkDDC
-            // 
-            this.chkDDC.AutoSize = true;
-            this.chkDDC.Checked = true;
-            this.chkDDC.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkDDC.Location = new System.Drawing.Point(150, 49);
-            this.chkDDC.Name = "chkDDC";
-            this.chkDDC.Size = new System.Drawing.Size(49, 17);
-            this.chkDDC.TabIndex = 13;
-            this.chkDDC.Text = "DDC";
-            this.chkDDC.UseVisualStyleBackColor = true;
-            this.chkDDC.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkLoLK
-            // 
-            this.chkLoLK.AutoSize = true;
-            this.chkLoLK.Checked = true;
-            this.chkLoLK.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkLoLK.Location = new System.Drawing.Point(205, 49);
-            this.chkLoLK.Name = "chkLoLK";
-            this.chkLoLK.Size = new System.Drawing.Size(51, 17);
-            this.chkLoLK.TabIndex = 14;
-            this.chkLoLK.Text = "LoLK";
-            this.chkLoLK.UseVisualStyleBackColor = true;
-            this.chkLoLK.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkHSiFS
-            // 
-            this.chkHSiFS.AutoSize = true;
-            this.chkHSiFS.Checked = true;
-            this.chkHSiFS.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkHSiFS.Location = new System.Drawing.Point(3, 72);
-            this.chkHSiFS.Name = "chkHSiFS";
-            this.chkHSiFS.Size = new System.Drawing.Size(56, 17);
-            this.chkHSiFS.TabIndex = 15;
-            this.chkHSiFS.Text = "HSiFS";
-            this.chkHSiFS.UseVisualStyleBackColor = true;
-            this.chkHSiFS.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkWBaWC
-            // 
-            this.chkWBaWC.AutoSize = true;
-            this.chkWBaWC.Checked = true;
-            this.chkWBaWC.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkWBaWC.Location = new System.Drawing.Point(65, 72);
-            this.chkWBaWC.Name = "chkWBaWC";
-            this.chkWBaWC.Size = new System.Drawing.Size(68, 17);
-            this.chkWBaWC.TabIndex = 16;
-            this.chkWBaWC.Text = "WBaWC";
-            this.chkWBaWC.UseVisualStyleBackColor = true;
-            this.chkWBaWC.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkUM
-            // 
-            this.chkUM.AutoSize = true;
-            this.chkUM.Checked = true;
-            this.chkUM.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkUM.Location = new System.Drawing.Point(139, 72);
-            this.chkUM.Name = "chkUM";
-            this.chkUM.Size = new System.Drawing.Size(43, 17);
-            this.chkUM.TabIndex = 17;
-            this.chkUM.Text = "UM";
-            this.chkUM.UseVisualStyleBackColor = true;
-            this.chkUM.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
             // 
             // launcherSettings
             // 
@@ -1359,7 +1406,7 @@
             this.replays.Location = new System.Drawing.Point(4, 22);
             this.replays.Name = "replays";
             this.replays.Padding = new System.Windows.Forms.Padding(3);
-            this.replays.Size = new System.Drawing.Size(527, 585);
+            this.replays.Size = new System.Drawing.Size(537, 555);
             this.replays.TabIndex = 3;
             this.replays.Text = "Replays";
             // 
@@ -1371,7 +1418,7 @@
             this.replayBrowser.Location = new System.Drawing.Point(0, 29);
             this.replayBrowser.MinimumSize = new System.Drawing.Size(20, 20);
             this.replayBrowser.Name = "replayBrowser";
-            this.replayBrowser.Size = new System.Drawing.Size(524, 556);
+            this.replayBrowser.Size = new System.Drawing.Size(534, 449);
             this.replayBrowser.TabIndex = 2;
             this.replayBrowser.Url = new System.Uri("", System.UriKind.Relative);
             this.replayBrowser.Navigating += new System.Windows.Forms.WebBrowserNavigatingEventHandler(this.replayBrowser_Navigating);
@@ -1386,7 +1433,7 @@
             this.replayPanel.Controls.Add(this.maribelReplays);
             this.replayPanel.Location = new System.Drawing.Point(0, 0);
             this.replayPanel.Name = "replayPanel";
-            this.replayPanel.Size = new System.Drawing.Size(518, 29);
+            this.replayPanel.Size = new System.Drawing.Size(528, 29);
             this.replayPanel.TabIndex = 1;
             // 
             // linkReplays
@@ -1436,7 +1483,7 @@
             this.customGames.Location = new System.Drawing.Point(4, 22);
             this.customGames.Name = "customGames";
             this.customGames.Padding = new System.Windows.Forms.Padding(3);
-            this.customGames.Size = new System.Drawing.Size(527, 585);
+            this.customGames.Size = new System.Drawing.Size(537, 555);
             this.customGames.TabIndex = 1;
             this.customGames.Text = "Custom Games";
             // 
@@ -1462,7 +1509,7 @@
             this.customList.LargeImageList = this.customImages;
             this.customList.Location = new System.Drawing.Point(272, 3);
             this.customList.Name = "customList";
-            this.customList.Size = new System.Drawing.Size(246, 579);
+            this.customList.Size = new System.Drawing.Size(256, 472);
             this.customList.SmallImageList = this.customImages;
             this.customList.TabIndex = 3;
             this.customList.UseCompatibleStateImageBehavior = false;
@@ -1476,7 +1523,7 @@
             // 
             this.customLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.customLabel.AutoSize = true;
-            this.customLabel.Location = new System.Drawing.Point(3, 687);
+            this.customLabel.Location = new System.Drawing.Point(3, 580);
             this.customLabel.Name = "customLabel";
             this.customLabel.Size = new System.Drawing.Size(0, 13);
             this.customLabel.TabIndex = 2;
@@ -1490,7 +1537,7 @@
             this.customTree.LabelEdit = true;
             this.customTree.Location = new System.Drawing.Point(3, 3);
             this.customTree.Name = "customTree";
-            this.customTree.Size = new System.Drawing.Size(167, 579);
+            this.customTree.Size = new System.Drawing.Size(167, 472);
             this.customTree.TabIndex = 1;
             this.customTree.AfterLabelEdit += new System.Windows.Forms.NodeLabelEditEventHandler(this.customTree_AfterLabelEdit);
             this.customTree.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.customTree_NodeMouseClick);
@@ -1509,54 +1556,53 @@
             this.mainControl.Margin = new System.Windows.Forms.Padding(1);
             this.mainControl.Name = "mainControl";
             this.mainControl.SelectedIndex = 0;
-            this.mainControl.Size = new System.Drawing.Size(535, 611);
+            this.mainControl.Size = new System.Drawing.Size(545, 581);
             this.mainControl.TabIndex = 0;
             this.mainControl.Deselected += new System.Windows.Forms.TabControlEventHandler(this.mainControl_Deselected);
             // 
             // games
             // 
             this.games.BackColor = System.Drawing.Color.Transparent;
+            this.games.Controls.Add(this.spinoffGroup);
             this.games.Controls.Add(this.btnRandom);
-            this.games.Controls.Add(this.otherGroup);
-            this.games.Controls.Add(this.fightingGroup);
+            this.games.Controls.Add(this.tasofroGroup);
             this.games.Controls.Add(this.mainGroup);
+            this.games.Controls.Add(this.pc98Group);
             this.games.Location = new System.Drawing.Point(4, 22);
             this.games.Name = "games";
             this.games.Padding = new System.Windows.Forms.Padding(3);
-            this.games.Size = new System.Drawing.Size(527, 585);
+            this.games.Size = new System.Drawing.Size(537, 555);
             this.games.TabIndex = 6;
             this.games.Text = "Games";
             // 
-            // otherGroup
+            // spinoffGroup
             // 
-            this.otherGroup.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.otherGroup.Controls.Add(this.miscLayoutPanel);
-            this.otherGroup.Location = new System.Drawing.Point(6, 413);
-            this.otherGroup.Name = "otherGroup";
-            this.otherGroup.Size = new System.Drawing.Size(512, 123);
-            this.otherGroup.TabIndex = 3;
-            this.otherGroup.TabStop = false;
-            this.otherGroup.Text = "Other Games";
+            this.spinoffGroup.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.spinoffGroup.Controls.Add(this.spinoffLayoutPanel);
+            this.spinoffGroup.Location = new System.Drawing.Point(6, 285);
+            this.spinoffGroup.Name = "spinoffGroup";
+            this.spinoffGroup.Size = new System.Drawing.Size(259, 223);
+            this.spinoffGroup.TabIndex = 3;
+            this.spinoffGroup.TabStop = false;
+            this.spinoffGroup.Text = "Spinoffs";
             // 
-            // miscLayoutPanel
+            // spinoffLayoutPanel
             // 
-            this.miscLayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.spinoffLayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.miscLayoutPanel.AutoScroll = true;
-            this.miscLayoutPanel.Controls.Add(this.btnStB);
-            this.miscLayoutPanel.Controls.Add(this.btnDS);
-            this.miscLayoutPanel.Controls.Add(this.btnGFW);
-            this.miscLayoutPanel.Controls.Add(this.btnISC);
-            this.miscLayoutPanel.Controls.Add(this.btnVD);
-            this.miscLayoutPanel.Controls.Add(this.btnGI);
-            this.miscLayoutPanel.Controls.Add(this.btnHBM);
-            this.miscLayoutPanel.Location = new System.Drawing.Point(3, 16);
-            this.miscLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
-            this.miscLayoutPanel.Name = "miscLayoutPanel";
-            this.miscLayoutPanel.Size = new System.Drawing.Size(506, 104);
-            this.miscLayoutPanel.TabIndex = 2;
+            this.spinoffLayoutPanel.AutoScroll = true;
+            this.spinoffLayoutPanel.Controls.Add(this.btnStB);
+            this.spinoffLayoutPanel.Controls.Add(this.btnDS);
+            this.spinoffLayoutPanel.Controls.Add(this.btnGFW);
+            this.spinoffLayoutPanel.Controls.Add(this.btnISC);
+            this.spinoffLayoutPanel.Controls.Add(this.btnVD);
+            this.spinoffLayoutPanel.Controls.Add(this.btnHBM);
+            this.spinoffLayoutPanel.Location = new System.Drawing.Point(3, 16);
+            this.spinoffLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.spinoffLayoutPanel.Name = "spinoffLayoutPanel";
+            this.spinoffLayoutPanel.Size = new System.Drawing.Size(253, 204);
+            this.spinoffLayoutPanel.TabIndex = 2;
             // 
             // btnStB
             // 
@@ -1601,7 +1647,7 @@
             this.btnGFW.ContextMenuStrip = this.gameContextMenu;
             this.btnGFW.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnGFW.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.btnGFW.Location = new System.Drawing.Point(255, 3);
+            this.btnGFW.Location = new System.Drawing.Point(3, 53);
             this.btnGFW.Name = "btnGFW";
             this.btnGFW.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnGFW.Size = new System.Drawing.Size(120, 44);
@@ -1619,7 +1665,7 @@
             this.btnISC.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnISC.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnISC.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnISC.Location = new System.Drawing.Point(381, 3);
+            this.btnISC.Location = new System.Drawing.Point(129, 53);
             this.btnISC.Name = "btnISC";
             this.btnISC.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnISC.Size = new System.Drawing.Size(120, 44);
@@ -1637,7 +1683,7 @@
             this.btnVD.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnVD.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnVD.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnVD.Location = new System.Drawing.Point(3, 53);
+            this.btnVD.Location = new System.Drawing.Point(3, 103);
             this.btnVD.Name = "btnVD";
             this.btnVD.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnVD.Size = new System.Drawing.Size(120, 44);
@@ -1647,53 +1693,54 @@
             this.btnVD.UseVisualStyleBackColor = true;
             this.btnVD.Click += new System.EventHandler(this.btn_Click);
             // 
-            // btnGI
+            // btnHBM
             // 
-            this.btnGI.BackgroundImage = global::Touhou_Launcher.Properties.Resources.gig;
-            this.btnGI.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.btnGI.ContextMenuStrip = this.gameContextMenu;
-            this.btnGI.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.btnGI.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.btnGI.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnGI.Location = new System.Drawing.Point(129, 53);
-            this.btnGI.Name = "btnGI";
-            this.btnGI.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
-            this.btnGI.Size = new System.Drawing.Size(120, 44);
-            this.btnGI.TabIndex = 5;
-            this.btnGI.Text = "Gouyoku Ibun";
-            this.btnGI.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnGI.UseVisualStyleBackColor = true;
-            this.btnGI.Click += new System.EventHandler(this.btn_Click);
+            this.btnHBM.BackgroundImage = global::Touhou_Launcher.Properties.Resources.hbmg;
+            this.btnHBM.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btnHBM.ContextMenuStrip = this.gameContextMenu;
+            this.btnHBM.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btnHBM.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.btnHBM.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.btnHBM.Location = new System.Drawing.Point(129, 103);
+            this.btnHBM.Name = "btnHBM";
+            this.btnHBM.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
+            this.btnHBM.Size = new System.Drawing.Size(120, 44);
+            this.btnHBM.TabIndex = 5;
+            this.btnHBM.Text = "100th Black Market";
+            this.btnHBM.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btnHBM.UseVisualStyleBackColor = true;
+            this.btnHBM.Click += new System.EventHandler(this.btn_Click);
             // 
-            // fightingGroup
+            // tasofroGroup
             // 
-            this.fightingGroup.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            this.tasofroGroup.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.fightingGroup.Controls.Add(this.fightingLayoutPanel);
-            this.fightingGroup.Location = new System.Drawing.Point(6, 284);
-            this.fightingGroup.Name = "fightingGroup";
-            this.fightingGroup.Size = new System.Drawing.Size(512, 123);
-            this.fightingGroup.TabIndex = 2;
-            this.fightingGroup.TabStop = false;
-            this.fightingGroup.Text = "Fighting Games";
+            this.tasofroGroup.Controls.Add(this.tasofroLayoutPanel);
+            this.tasofroGroup.Location = new System.Drawing.Point(271, 285);
+            this.tasofroGroup.Name = "tasofroGroup";
+            this.tasofroGroup.Size = new System.Drawing.Size(259, 223);
+            this.tasofroGroup.TabIndex = 4;
+            this.tasofroGroup.TabStop = false;
+            this.tasofroGroup.Text = "Twilight Frontier Games";
             // 
-            // fightingLayoutPanel
+            // tasofroLayoutPanel
             // 
-            this.fightingLayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.tasofroLayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.fightingLayoutPanel.AutoScroll = true;
-            this.fightingLayoutPanel.Controls.Add(this.btnIaMP);
-            this.fightingLayoutPanel.Controls.Add(this.btnSWR);
-            this.fightingLayoutPanel.Controls.Add(this.btnUoNL);
-            this.fightingLayoutPanel.Controls.Add(this.btnHM);
-            this.fightingLayoutPanel.Controls.Add(this.btnULiL);
-            this.fightingLayoutPanel.Controls.Add(this.btnAoCF);
-            this.fightingLayoutPanel.Location = new System.Drawing.Point(3, 16);
-            this.fightingLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
-            this.fightingLayoutPanel.Name = "fightingLayoutPanel";
-            this.fightingLayoutPanel.Size = new System.Drawing.Size(506, 104);
-            this.fightingLayoutPanel.TabIndex = 2;
+            this.tasofroLayoutPanel.AutoScroll = true;
+            this.tasofroLayoutPanel.Controls.Add(this.btnIaMP);
+            this.tasofroLayoutPanel.Controls.Add(this.btnSWR);
+            this.tasofroLayoutPanel.Controls.Add(this.btnUoNL);
+            this.tasofroLayoutPanel.Controls.Add(this.btnHM);
+            this.tasofroLayoutPanel.Controls.Add(this.btnULiL);
+            this.tasofroLayoutPanel.Controls.Add(this.btnAoCF);
+            this.tasofroLayoutPanel.Controls.Add(this.btnGI);
+            this.tasofroLayoutPanel.Location = new System.Drawing.Point(3, 16);
+            this.tasofroLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.tasofroLayoutPanel.Name = "tasofroLayoutPanel";
+            this.tasofroLayoutPanel.Size = new System.Drawing.Size(253, 204);
+            this.tasofroLayoutPanel.TabIndex = 2;
             // 
             // btnIaMP
             // 
@@ -1739,7 +1786,7 @@
             this.btnUoNL.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnUoNL.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnUoNL.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnUoNL.Location = new System.Drawing.Point(255, 3);
+            this.btnUoNL.Location = new System.Drawing.Point(3, 53);
             this.btnUoNL.Name = "btnUoNL";
             this.btnUoNL.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnUoNL.Size = new System.Drawing.Size(120, 44);
@@ -1757,7 +1804,7 @@
             this.btnHM.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnHM.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnHM.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnHM.Location = new System.Drawing.Point(381, 3);
+            this.btnHM.Location = new System.Drawing.Point(129, 53);
             this.btnHM.Name = "btnHM";
             this.btnHM.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnHM.Size = new System.Drawing.Size(120, 44);
@@ -1775,7 +1822,7 @@
             this.btnULiL.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnULiL.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnULiL.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnULiL.Location = new System.Drawing.Point(3, 53);
+            this.btnULiL.Location = new System.Drawing.Point(3, 103);
             this.btnULiL.Name = "btnULiL";
             this.btnULiL.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnULiL.Size = new System.Drawing.Size(120, 44);
@@ -1793,7 +1840,7 @@
             this.btnAoCF.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnAoCF.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnAoCF.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnAoCF.Location = new System.Drawing.Point(129, 53);
+            this.btnAoCF.Location = new System.Drawing.Point(129, 103);
             this.btnAoCF.Name = "btnAoCF";
             this.btnAoCF.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnAoCF.Size = new System.Drawing.Size(120, 44);
@@ -1803,16 +1850,34 @@
             this.btnAoCF.UseVisualStyleBackColor = true;
             this.btnAoCF.Click += new System.EventHandler(this.btn_Click);
             // 
+            // btnGI
+            // 
+            this.btnGI.BackgroundImage = global::Touhou_Launcher.Properties.Resources.gig;
+            this.btnGI.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btnGI.ContextMenuStrip = this.gameContextMenu;
+            this.btnGI.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btnGI.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.btnGI.ForeColor = System.Drawing.SystemColors.Window;
+            this.btnGI.Location = new System.Drawing.Point(3, 153);
+            this.btnGI.Name = "btnGI";
+            this.btnGI.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
+            this.btnGI.Size = new System.Drawing.Size(120, 44);
+            this.btnGI.TabIndex = 6;
+            this.btnGI.Text = "Gouyoku Ibun";
+            this.btnGI.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btnGI.UseVisualStyleBackColor = true;
+            this.btnGI.Click += new System.EventHandler(this.btn_Click);
+            // 
             // mainGroup
             // 
             this.mainGroup.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.mainGroup.Controls.Add(this.mainLayoutPanel);
-            this.mainGroup.Location = new System.Drawing.Point(6, 6);
+            this.mainGroup.Location = new System.Drawing.Point(145, 6);
             this.mainGroup.Name = "mainGroup";
-            this.mainGroup.Size = new System.Drawing.Size(512, 272);
-            this.mainGroup.TabIndex = 1;
+            this.mainGroup.Size = new System.Drawing.Size(385, 273);
+            this.mainGroup.TabIndex = 2;
             this.mainGroup.TabStop = false;
             this.mainGroup.Text = "Main Games";
             // 
@@ -1822,11 +1887,6 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.mainLayoutPanel.AutoScroll = true;
-            this.mainLayoutPanel.Controls.Add(this.btnHRtP);
-            this.mainLayoutPanel.Controls.Add(this.btnSoEW);
-            this.mainLayoutPanel.Controls.Add(this.btnPoDD);
-            this.mainLayoutPanel.Controls.Add(this.btnLLS);
-            this.mainLayoutPanel.Controls.Add(this.btnMS);
             this.mainLayoutPanel.Controls.Add(this.btnEoSD);
             this.mainLayoutPanel.Controls.Add(this.btnPCB);
             this.mainLayoutPanel.Controls.Add(this.btnIN);
@@ -1843,7 +1903,7 @@
             this.mainLayoutPanel.Location = new System.Drawing.Point(3, 16);
             this.mainLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
             this.mainLayoutPanel.Name = "mainLayoutPanel";
-            this.mainLayoutPanel.Size = new System.Drawing.Size(506, 253);
+            this.mainLayoutPanel.Size = new System.Drawing.Size(379, 254);
             this.mainLayoutPanel.TabIndex = 2;
             // 
             // btnEoSD
@@ -1854,11 +1914,11 @@
             this.btnEoSD.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnEoSD.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnEoSD.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnEoSD.Location = new System.Drawing.Point(129, 53);
+            this.btnEoSD.Location = new System.Drawing.Point(3, 3);
             this.btnEoSD.Name = "btnEoSD";
             this.btnEoSD.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnEoSD.Size = new System.Drawing.Size(120, 44);
-            this.btnEoSD.TabIndex = 5;
+            this.btnEoSD.TabIndex = 0;
             this.btnEoSD.Text = "Embodiment of Scarlet Devil";
             this.btnEoSD.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnEoSD.UseVisualStyleBackColor = true;
@@ -1872,11 +1932,11 @@
             this.btnPCB.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnPCB.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnPCB.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnPCB.Location = new System.Drawing.Point(255, 53);
+            this.btnPCB.Location = new System.Drawing.Point(129, 3);
             this.btnPCB.Name = "btnPCB";
             this.btnPCB.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnPCB.Size = new System.Drawing.Size(120, 44);
-            this.btnPCB.TabIndex = 6;
+            this.btnPCB.TabIndex = 1;
             this.btnPCB.Text = "Perfect Cherry Blossom";
             this.btnPCB.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnPCB.UseVisualStyleBackColor = true;
@@ -1890,11 +1950,11 @@
             this.btnIN.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnIN.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnIN.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnIN.Location = new System.Drawing.Point(381, 53);
+            this.btnIN.Location = new System.Drawing.Point(255, 3);
             this.btnIN.Name = "btnIN";
             this.btnIN.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnIN.Size = new System.Drawing.Size(120, 44);
-            this.btnIN.TabIndex = 7;
+            this.btnIN.TabIndex = 2;
             this.btnIN.Text = "Imperishable Night";
             this.btnIN.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnIN.UseVisualStyleBackColor = true;
@@ -1908,11 +1968,11 @@
             this.btnPoFV.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnPoFV.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnPoFV.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnPoFV.Location = new System.Drawing.Point(3, 103);
+            this.btnPoFV.Location = new System.Drawing.Point(3, 53);
             this.btnPoFV.Name = "btnPoFV";
             this.btnPoFV.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnPoFV.Size = new System.Drawing.Size(120, 44);
-            this.btnPoFV.TabIndex = 8;
+            this.btnPoFV.TabIndex = 3;
             this.btnPoFV.Text = "Phantasmagoria of Flower View";
             this.btnPoFV.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnPoFV.UseVisualStyleBackColor = true;
@@ -1926,11 +1986,11 @@
             this.btnMoF.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnMoF.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnMoF.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnMoF.Location = new System.Drawing.Point(129, 103);
+            this.btnMoF.Location = new System.Drawing.Point(129, 53);
             this.btnMoF.Name = "btnMoF";
             this.btnMoF.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnMoF.Size = new System.Drawing.Size(120, 44);
-            this.btnMoF.TabIndex = 9;
+            this.btnMoF.TabIndex = 4;
             this.btnMoF.Text = "Mountain of Faith";
             this.btnMoF.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnMoF.UseVisualStyleBackColor = true;
@@ -1944,11 +2004,11 @@
             this.btnSA.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnSA.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnSA.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnSA.Location = new System.Drawing.Point(255, 103);
+            this.btnSA.Location = new System.Drawing.Point(255, 53);
             this.btnSA.Name = "btnSA";
             this.btnSA.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnSA.Size = new System.Drawing.Size(120, 44);
-            this.btnSA.TabIndex = 10;
+            this.btnSA.TabIndex = 5;
             this.btnSA.Text = "Subterranean Animism";
             this.btnSA.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnSA.UseVisualStyleBackColor = true;
@@ -1962,11 +2022,11 @@
             this.btnUFO.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnUFO.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnUFO.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnUFO.Location = new System.Drawing.Point(381, 103);
+            this.btnUFO.Location = new System.Drawing.Point(3, 103);
             this.btnUFO.Name = "btnUFO";
             this.btnUFO.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnUFO.Size = new System.Drawing.Size(120, 44);
-            this.btnUFO.TabIndex = 11;
+            this.btnUFO.TabIndex = 6;
             this.btnUFO.Text = "Undefined Fantastic Object";
             this.btnUFO.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnUFO.UseVisualStyleBackColor = true;
@@ -1980,11 +2040,11 @@
             this.btnTD.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnTD.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnTD.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnTD.Location = new System.Drawing.Point(3, 153);
+            this.btnTD.Location = new System.Drawing.Point(129, 103);
             this.btnTD.Name = "btnTD";
             this.btnTD.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnTD.Size = new System.Drawing.Size(120, 44);
-            this.btnTD.TabIndex = 12;
+            this.btnTD.TabIndex = 7;
             this.btnTD.Text = "Ten Desires";
             this.btnTD.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnTD.UseVisualStyleBackColor = true;
@@ -1998,11 +2058,11 @@
             this.btnDDC.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnDDC.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnDDC.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnDDC.Location = new System.Drawing.Point(129, 153);
+            this.btnDDC.Location = new System.Drawing.Point(255, 103);
             this.btnDDC.Name = "btnDDC";
             this.btnDDC.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnDDC.Size = new System.Drawing.Size(120, 44);
-            this.btnDDC.TabIndex = 13;
+            this.btnDDC.TabIndex = 8;
             this.btnDDC.Text = "Double Dealing Character";
             this.btnDDC.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnDDC.UseVisualStyleBackColor = true;
@@ -2016,11 +2076,11 @@
             this.btnLoLK.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnLoLK.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnLoLK.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnLoLK.Location = new System.Drawing.Point(255, 153);
+            this.btnLoLK.Location = new System.Drawing.Point(3, 153);
             this.btnLoLK.Name = "btnLoLK";
             this.btnLoLK.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnLoLK.Size = new System.Drawing.Size(120, 44);
-            this.btnLoLK.TabIndex = 14;
+            this.btnLoLK.TabIndex = 9;
             this.btnLoLK.Text = "Legacy of Lunatic Kingdom";
             this.btnLoLK.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnLoLK.UseVisualStyleBackColor = true;
@@ -2034,11 +2094,11 @@
             this.btnHSiFS.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnHSiFS.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnHSiFS.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnHSiFS.Location = new System.Drawing.Point(381, 153);
+            this.btnHSiFS.Location = new System.Drawing.Point(129, 153);
             this.btnHSiFS.Name = "btnHSiFS";
             this.btnHSiFS.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnHSiFS.Size = new System.Drawing.Size(120, 44);
-            this.btnHSiFS.TabIndex = 15;
+            this.btnHSiFS.TabIndex = 10;
             this.btnHSiFS.Text = "Hidden Star in Four Seasons";
             this.btnHSiFS.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnHSiFS.UseVisualStyleBackColor = true;
@@ -2052,11 +2112,11 @@
             this.btnWBaWC.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnWBaWC.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnWBaWC.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnWBaWC.Location = new System.Drawing.Point(3, 203);
+            this.btnWBaWC.Location = new System.Drawing.Point(255, 153);
             this.btnWBaWC.Name = "btnWBaWC";
             this.btnWBaWC.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnWBaWC.Size = new System.Drawing.Size(120, 44);
-            this.btnWBaWC.TabIndex = 16;
+            this.btnWBaWC.TabIndex = 11;
             this.btnWBaWC.Text = "Wily Beast and Weakest Creature";
             this.btnWBaWC.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnWBaWC.UseVisualStyleBackColor = true;
@@ -2070,39 +2130,121 @@
             this.btnUM.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnUM.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnUM.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnUM.Location = new System.Drawing.Point(129, 203);
+            this.btnUM.Location = new System.Drawing.Point(3, 203);
             this.btnUM.Name = "btnUM";
             this.btnUM.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnUM.Size = new System.Drawing.Size(120, 44);
-            this.btnUM.TabIndex = 17;
+            this.btnUM.TabIndex = 12;
             this.btnUM.Text = "Unconnected Marketeers";
             this.btnUM.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnUM.UseVisualStyleBackColor = true;
             this.btnUM.Click += new System.EventHandler(this.btn_Click);
             // 
+            // pc98Group
+            // 
+            this.pc98Group.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.pc98Group.Controls.Add(this.pc98LayoutPanel);
+            this.pc98Group.Location = new System.Drawing.Point(6, 6);
+            this.pc98Group.Name = "pc98Group";
+            this.pc98Group.Size = new System.Drawing.Size(133, 273);
+            this.pc98Group.TabIndex = 1;
+            this.pc98Group.TabStop = false;
+            this.pc98Group.Text = "PC-98 Games";
+            // 
+            // pc98LayoutPanel
+            // 
+            this.pc98LayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pc98LayoutPanel.AutoScroll = true;
+            this.pc98LayoutPanel.Controls.Add(this.btnHRtP);
+            this.pc98LayoutPanel.Controls.Add(this.btnSoEW);
+            this.pc98LayoutPanel.Controls.Add(this.btnPoDD);
+            this.pc98LayoutPanel.Controls.Add(this.btnLLS);
+            this.pc98LayoutPanel.Controls.Add(this.btnMS);
+            this.pc98LayoutPanel.Location = new System.Drawing.Point(3, 16);
+            this.pc98LayoutPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.pc98LayoutPanel.Name = "pc98LayoutPanel";
+            this.pc98LayoutPanel.Size = new System.Drawing.Size(127, 254);
+            this.pc98LayoutPanel.TabIndex = 2;
+            // 
             // trayMenu
             // 
             this.trayMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.trayPC98,
             this.trayMain,
-            this.trayFighting,
-            this.trayOther,
+            this.traySpinoff,
+            this.trayTasofro,
             this.trayCustom,
             this.trayRandom,
             this.toolStripSeparator2,
             this.trayOpen,
             this.trayExit});
             this.trayMenu.Name = "contextMenuStrip1";
-            this.trayMenu.Size = new System.Drawing.Size(158, 164);
+            this.trayMenu.Size = new System.Drawing.Size(201, 186);
             this.trayMenu.Opening += new System.ComponentModel.CancelEventHandler(this.trayMenu_Opening);
             // 
-            // trayMain
+            // trayPC98
             // 
-            this.trayMain.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.trayPC98.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.trayHRtP,
             this.traySoEW,
             this.trayPoDD,
             this.trayLLS,
-            this.trayMS,
+            this.trayMS});
+            this.trayPC98.Name = "trayPC98";
+            this.trayPC98.Size = new System.Drawing.Size(200, 22);
+            this.trayPC98.Text = "PC-98 Games";
+            // 
+            // trayHRtP
+            // 
+            this.trayHRtP.Image = global::Touhou_Launcher.Properties.Resources.Icon_th01;
+            this.trayHRtP.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayHRtP.Name = "trayHRtP";
+            this.trayHRtP.Size = new System.Drawing.Size(256, 38);
+            this.trayHRtP.Text = "Highly Responsive to Prayers";
+            this.trayHRtP.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // traySoEW
+            // 
+            this.traySoEW.Image = global::Touhou_Launcher.Properties.Resources.Icon_th02;
+            this.traySoEW.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.traySoEW.Name = "traySoEW";
+            this.traySoEW.Size = new System.Drawing.Size(256, 38);
+            this.traySoEW.Text = "Story of Eastern Wonderland";
+            this.traySoEW.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayPoDD
+            // 
+            this.trayPoDD.Image = global::Touhou_Launcher.Properties.Resources.Icon_th03;
+            this.trayPoDD.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayPoDD.Name = "trayPoDD";
+            this.trayPoDD.Size = new System.Drawing.Size(256, 38);
+            this.trayPoDD.Text = "Phantasmagoria of Dim. Dream";
+            this.trayPoDD.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayLLS
+            // 
+            this.trayLLS.Image = global::Touhou_Launcher.Properties.Resources.Icon_th04;
+            this.trayLLS.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayLLS.Name = "trayLLS";
+            this.trayLLS.Size = new System.Drawing.Size(256, 38);
+            this.trayLLS.Text = "Lotus Land Story";
+            this.trayLLS.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayMS
+            // 
+            this.trayMS.Image = global::Touhou_Launcher.Properties.Resources.Icon_th05;
+            this.trayMS.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayMS.Name = "trayMS";
+            this.trayMS.Size = new System.Drawing.Size(256, 38);
+            this.trayMS.Text = "Mystic Square";
+            this.trayMS.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayMain
+            // 
+            this.trayMain.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.trayEoSD,
             this.trayPCB,
             this.trayIN,
@@ -2117,53 +2259,8 @@
             this.trayWBaWC,
             this.trayUM});
             this.trayMain.Name = "trayMain";
-            this.trayMain.Size = new System.Drawing.Size(157, 22);
+            this.trayMain.Size = new System.Drawing.Size(200, 22);
             this.trayMain.Text = "Main Games";
-            // 
-            // trayHRtP
-            // 
-            this.trayHRtP.Image = global::Touhou_Launcher.Properties.Resources.Icon_th01;
-            this.trayHRtP.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayHRtP.Name = "trayHRtP";
-            this.trayHRtP.Size = new System.Drawing.Size(262, 38);
-            this.trayHRtP.Text = "Highly Responsive to Prayers";
-            this.trayHRtP.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // traySoEW
-            // 
-            this.traySoEW.Image = global::Touhou_Launcher.Properties.Resources.Icon_th02;
-            this.traySoEW.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.traySoEW.Name = "traySoEW";
-            this.traySoEW.Size = new System.Drawing.Size(262, 38);
-            this.traySoEW.Text = "Story of Eastern Wonderland";
-            this.traySoEW.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // trayPoDD
-            // 
-            this.trayPoDD.Image = global::Touhou_Launcher.Properties.Resources.Icon_th03;
-            this.trayPoDD.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayPoDD.Name = "trayPoDD";
-            this.trayPoDD.Size = new System.Drawing.Size(262, 38);
-            this.trayPoDD.Text = "Phantasmagoria of Dim. Dream";
-            this.trayPoDD.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // trayLLS
-            // 
-            this.trayLLS.Image = global::Touhou_Launcher.Properties.Resources.Icon_th04;
-            this.trayLLS.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayLLS.Name = "trayLLS";
-            this.trayLLS.Size = new System.Drawing.Size(262, 38);
-            this.trayLLS.Text = "Lotus Land Story";
-            this.trayLLS.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // trayMS
-            // 
-            this.trayMS.Image = global::Touhou_Launcher.Properties.Resources.Icon_th05;
-            this.trayMS.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayMS.Name = "trayMS";
-            this.trayMS.Size = new System.Drawing.Size(262, 38);
-            this.trayMS.Text = "Mystic Square";
-            this.trayMS.Click += new System.EventHandler(this.tray_Click);
             // 
             // trayEoSD
             // 
@@ -2282,18 +2379,86 @@
             this.trayUM.Text = "Unconnected Marketeers";
             this.trayUM.Click += new System.EventHandler(this.tray_Click);
             // 
-            // trayFighting
+            // traySpinoff
             // 
-            this.trayFighting.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.traySpinoff.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.trayStB,
+            this.trayDS,
+            this.trayGFW,
+            this.trayISC,
+            this.trayVD,
+            this.trayHBM});
+            this.traySpinoff.Name = "traySpinoff";
+            this.traySpinoff.Size = new System.Drawing.Size(200, 22);
+            this.traySpinoff.Text = "Spinoffs";
+            // 
+            // trayStB
+            // 
+            this.trayStB.Image = global::Touhou_Launcher.Properties.Resources.Icon_th095;
+            this.trayStB.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayStB.Name = "trayStB";
+            this.trayStB.Size = new System.Drawing.Size(203, 38);
+            this.trayStB.Text = "Shoot the Bullet";
+            this.trayStB.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayDS
+            // 
+            this.trayDS.Image = global::Touhou_Launcher.Properties.Resources.Icon_th125;
+            this.trayDS.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayDS.Name = "trayDS";
+            this.trayDS.Size = new System.Drawing.Size(203, 38);
+            this.trayDS.Text = "Double Spoiler";
+            this.trayDS.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayGFW
+            // 
+            this.trayGFW.Image = global::Touhou_Launcher.Properties.Resources.Icon_th128;
+            this.trayGFW.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayGFW.Name = "trayGFW";
+            this.trayGFW.Size = new System.Drawing.Size(203, 38);
+            this.trayGFW.Text = "Great Fairy Wars";
+            this.trayGFW.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayISC
+            // 
+            this.trayISC.Image = global::Touhou_Launcher.Properties.Resources.Icon_th143;
+            this.trayISC.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayISC.Name = "trayISC";
+            this.trayISC.Size = new System.Drawing.Size(203, 38);
+            this.trayISC.Text = "Impossible Spell Card";
+            this.trayISC.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayVD
+            // 
+            this.trayVD.Image = global::Touhou_Launcher.Properties.Resources.Icon_th165;
+            this.trayVD.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayVD.Name = "trayVD";
+            this.trayVD.Size = new System.Drawing.Size(203, 38);
+            this.trayVD.Text = "Violet Detector";
+            this.trayVD.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayHBM
+            // 
+            this.trayHBM.Image = global::Touhou_Launcher.Properties.Resources.Icon_th185;
+            this.trayHBM.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayHBM.Name = "trayHBM";
+            this.trayHBM.Size = new System.Drawing.Size(203, 38);
+            this.trayHBM.Text = "100th Black Market";
+            this.trayHBM.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayTasofro
+            // 
+            this.trayTasofro.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.trayIaMP,
             this.traySWR,
             this.trayUoNL,
             this.trayHM,
             this.trayULiL,
-            this.trayAoCF});
-            this.trayFighting.Name = "trayFighting";
-            this.trayFighting.Size = new System.Drawing.Size(157, 22);
-            this.trayFighting.Text = "Fighting Games";
+            this.trayAoCF,
+            this.trayGI});
+            this.trayTasofro.Name = "trayTasofro";
+            this.trayTasofro.Size = new System.Drawing.Size(200, 22);
+            this.trayTasofro.Text = "Twilight Frontier Games";
             // 
             // trayIaMP
             // 
@@ -2349,103 +2514,44 @@
             this.trayAoCF.Text = "Antinomy of Common Flowers";
             this.trayAoCF.Click += new System.EventHandler(this.tray_Click);
             // 
-            // trayOther
-            // 
-            this.trayOther.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.trayStB,
-            this.trayDS,
-            this.trayGFW,
-            this.trayISC,
-            this.trayVD,
-            this.trayGI,
-            this.trayHBM});
-            this.trayOther.Name = "trayOther";
-            this.trayOther.Size = new System.Drawing.Size(157, 22);
-            this.trayOther.Text = "Other Games";
-            // 
-            // trayStB
-            // 
-            this.trayStB.Image = global::Touhou_Launcher.Properties.Resources.Icon_th095;
-            this.trayStB.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayStB.Name = "trayStB";
-            this.trayStB.Size = new System.Drawing.Size(203, 38);
-            this.trayStB.Text = "Shoot the Bullet";
-            this.trayStB.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // trayDS
-            // 
-            this.trayDS.Image = global::Touhou_Launcher.Properties.Resources.Icon_th125;
-            this.trayDS.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayDS.Name = "trayDS";
-            this.trayDS.Size = new System.Drawing.Size(203, 38);
-            this.trayDS.Text = "Double Spoiler";
-            this.trayDS.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // trayGFW
-            // 
-            this.trayGFW.Image = global::Touhou_Launcher.Properties.Resources.Icon_th128;
-            this.trayGFW.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayGFW.Name = "trayGFW";
-            this.trayGFW.Size = new System.Drawing.Size(203, 38);
-            this.trayGFW.Text = "Great Fairy Wars";
-            this.trayGFW.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // trayISC
-            // 
-            this.trayISC.Image = global::Touhou_Launcher.Properties.Resources.Icon_th143;
-            this.trayISC.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayISC.Name = "trayISC";
-            this.trayISC.Size = new System.Drawing.Size(203, 38);
-            this.trayISC.Text = "Impossible Spell Card";
-            this.trayISC.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // trayVD
-            // 
-            this.trayVD.Image = global::Touhou_Launcher.Properties.Resources.Icon_th165;
-            this.trayVD.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayVD.Name = "trayVD";
-            this.trayVD.Size = new System.Drawing.Size(203, 38);
-            this.trayVD.Text = "Violet Detector";
-            this.trayVD.Click += new System.EventHandler(this.tray_Click);
-            // 
             // trayGI
             // 
             this.trayGI.Image = global::Touhou_Launcher.Properties.Resources.Icon_th175;
             this.trayGI.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.trayGI.Name = "trayGI";
-            this.trayGI.Size = new System.Drawing.Size(203, 38);
+            this.trayGI.Size = new System.Drawing.Size(254, 38);
             this.trayGI.Text = "Gouyoku Ibun";
             this.trayGI.Click += new System.EventHandler(this.tray_Click);
             // 
             // trayCustom
             // 
             this.trayCustom.Name = "trayCustom";
-            this.trayCustom.Size = new System.Drawing.Size(157, 22);
+            this.trayCustom.Size = new System.Drawing.Size(200, 22);
             this.trayCustom.Text = "Custom Games";
             // 
             // trayRandom
             // 
             this.trayRandom.Name = "trayRandom";
-            this.trayRandom.Size = new System.Drawing.Size(157, 22);
+            this.trayRandom.Size = new System.Drawing.Size(200, 22);
             this.trayRandom.Text = "Random Game";
             this.trayRandom.Click += new System.EventHandler(this.btnRandom_Click);
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(154, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(197, 6);
             // 
             // trayOpen
             // 
             this.trayOpen.Name = "trayOpen";
-            this.trayOpen.Size = new System.Drawing.Size(157, 22);
+            this.trayOpen.Size = new System.Drawing.Size(200, 22);
             this.trayOpen.Text = "Open";
             this.trayOpen.Click += new System.EventHandler(this.MainForm_Show);
             // 
             // trayExit
             // 
             this.trayExit.Name = "trayExit";
-            this.trayExit.Size = new System.Drawing.Size(157, 22);
+            this.trayExit.Size = new System.Drawing.Size(200, 22);
             this.trayExit.Text = "Exit";
             this.trayExit.Click += new System.EventHandler(this.trayExit_Click);
             // 
@@ -2456,51 +2562,11 @@
             this.trayIcon.Text = "Touhou Launcher";
             this.trayIcon.DoubleClick += new System.EventHandler(this.MainForm_Show);
             // 
-            // btnHBM
-            // 
-            this.btnHBM.BackgroundImage = global::Touhou_Launcher.Properties.Resources.hbmg;
-            this.btnHBM.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.btnHBM.ContextMenuStrip = this.gameContextMenu;
-            this.btnHBM.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.btnHBM.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.btnHBM.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnHBM.Location = new System.Drawing.Point(255, 53);
-            this.btnHBM.Name = "btnHBM";
-            this.btnHBM.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
-            this.btnHBM.Size = new System.Drawing.Size(120, 44);
-            this.btnHBM.TabIndex = 6;
-            this.btnHBM.Text = "100th Black Market";
-            this.btnHBM.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnHBM.UseVisualStyleBackColor = true;
-            this.btnHBM.Click += new System.EventHandler(this.btn_Click);
-            // 
-            // trayHBM
-            // 
-            this.trayHBM.Image = global::Touhou_Launcher.Properties.Resources.Icon_th185;
-            this.trayHBM.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayHBM.Name = "trayHBM";
-            this.trayHBM.Size = new System.Drawing.Size(203, 38);
-            this.trayHBM.Text = "100th Black Market";
-            this.trayHBM.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // chkHBM
-            // 
-            this.chkHBM.AutoSize = true;
-            this.chkHBM.Checked = true;
-            this.chkHBM.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkHBM.Location = new System.Drawing.Point(46, 26);
-            this.chkHBM.Name = "chkHBM";
-            this.chkHBM.Size = new System.Drawing.Size(60, 17);
-            this.chkHBM.TabIndex = 6;
-            this.chkHBM.Text = "100BM";
-            this.chkHBM.UseVisualStyleBackColor = true;
-            this.chkHBM.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(534, 612);
+            this.ClientSize = new System.Drawing.Size(544, 582);
             this.Controls.Add(this.mainControl);
             this.Icon = global::Touhou_Launcher.Properties.Resources.thicon;
             this.MinimumSize = new System.Drawing.Size(440, 450);
@@ -2515,15 +2581,18 @@
             this.info.PerformLayout();
             this.settings.ResumeLayout(false);
             this.randomSettings.ResumeLayout(false);
-            this.otherRandom.ResumeLayout(false);
-            this.miscRandomPanel.ResumeLayout(false);
-            this.miscRandomPanel.PerformLayout();
-            this.fightingRandom.ResumeLayout(false);
-            this.fightingRandomPanel.ResumeLayout(false);
-            this.fightingRandomPanel.PerformLayout();
+            this.spinoffRandom.ResumeLayout(false);
+            this.spinoffRandomPanel.ResumeLayout(false);
+            this.spinoffRandomPanel.PerformLayout();
+            this.tasofroRandom.ResumeLayout(false);
+            this.tasofroRandomPanel.ResumeLayout(false);
+            this.tasofroRandomPanel.PerformLayout();
             this.mainRandom.ResumeLayout(false);
             this.mainRandomPanel.ResumeLayout(false);
             this.mainRandomPanel.PerformLayout();
+            this.pc98Random.ResumeLayout(false);
+            this.pc98RandomPanel.ResumeLayout(false);
+            this.pc98RandomPanel.PerformLayout();
             this.launcherSettings.ResumeLayout(false);
             this.launcherSettings.PerformLayout();
             this.replays.ResumeLayout(false);
@@ -2533,12 +2602,14 @@
             this.customGames.PerformLayout();
             this.mainControl.ResumeLayout(false);
             this.games.ResumeLayout(false);
-            this.otherGroup.ResumeLayout(false);
-            this.miscLayoutPanel.ResumeLayout(false);
-            this.fightingGroup.ResumeLayout(false);
-            this.fightingLayoutPanel.ResumeLayout(false);
+            this.spinoffGroup.ResumeLayout(false);
+            this.spinoffLayoutPanel.ResumeLayout(false);
+            this.tasofroGroup.ResumeLayout(false);
+            this.tasofroLayoutPanel.ResumeLayout(false);
             this.mainGroup.ResumeLayout(false);
             this.mainLayoutPanel.ResumeLayout(false);
+            this.pc98Group.ResumeLayout(false);
+            this.pc98LayoutPanel.ResumeLayout(false);
             this.trayMenu.ResumeLayout(false);
             this.ResumeLayout(false);
 
@@ -2583,9 +2654,9 @@
         private System.Windows.Forms.TreeView customTree;
         private System.Windows.Forms.TabControl mainControl;
         private System.Windows.Forms.TabPage games;
-        private System.Windows.Forms.GroupBox mainGroup;
+        private System.Windows.Forms.GroupBox pc98Group;
         private System.Windows.Forms.Button btnHRtP;
-        private System.Windows.Forms.FlowLayoutPanel mainLayoutPanel;
+        private System.Windows.Forms.FlowLayoutPanel pc98LayoutPanel;
         private System.Windows.Forms.Button btnSoEW;
         private System.Windows.Forms.Button btnRandom;
         private System.Windows.Forms.Button btnPoDD;
@@ -2602,16 +2673,16 @@
         private System.Windows.Forms.Button btnDDC;
         private System.Windows.Forms.Button btnLoLK;
         private System.Windows.Forms.Button btnHSiFS;
-        private System.Windows.Forms.GroupBox fightingGroup;
-        private System.Windows.Forms.FlowLayoutPanel fightingLayoutPanel;
+        private System.Windows.Forms.GroupBox mainGroup;
+        private System.Windows.Forms.FlowLayoutPanel mainLayoutPanel;
         private System.Windows.Forms.Button btnIaMP;
         private System.Windows.Forms.Button btnSWR;
         private System.Windows.Forms.Button btnUoNL;
         private System.Windows.Forms.Button btnHM;
         private System.Windows.Forms.Button btnULiL;
         private System.Windows.Forms.Button btnAoCF;
-        private System.Windows.Forms.GroupBox otherGroup;
-        private System.Windows.Forms.FlowLayoutPanel miscLayoutPanel;
+        private System.Windows.Forms.GroupBox tasofroGroup;
+        private System.Windows.Forms.FlowLayoutPanel tasofroLayoutPanel;
         private System.Windows.Forms.Button btnStB;
         private System.Windows.Forms.Button btnDS;
         private System.Windows.Forms.Button btnGFW;
@@ -2623,23 +2694,23 @@
         private System.Windows.Forms.GroupBox randomSettings;
         private System.Windows.Forms.Button randomNone;
         private System.Windows.Forms.Button randomAll;
-        private System.Windows.Forms.GroupBox otherRandom;
-        private System.Windows.Forms.FlowLayoutPanel miscRandomPanel;
+        private System.Windows.Forms.GroupBox tasofroRandom;
+        private System.Windows.Forms.FlowLayoutPanel tasofroRandomPanel;
         private System.Windows.Forms.CheckBox chkStB;
         private System.Windows.Forms.CheckBox chkDS;
         private System.Windows.Forms.CheckBox chkGFW;
         private System.Windows.Forms.CheckBox chkISC;
         private System.Windows.Forms.CheckBox chkVD;
-        private System.Windows.Forms.GroupBox fightingRandom;
-        private System.Windows.Forms.FlowLayoutPanel fightingRandomPanel;
+        private System.Windows.Forms.GroupBox mainRandom;
+        private System.Windows.Forms.FlowLayoutPanel mainRandomPanel;
         private System.Windows.Forms.CheckBox chkIaMP;
         private System.Windows.Forms.CheckBox chkSWR;
         private System.Windows.Forms.CheckBox chkUoNL;
         private System.Windows.Forms.CheckBox chkHM;
         private System.Windows.Forms.CheckBox chkULiL;
         private System.Windows.Forms.CheckBox chkAoCF;
-        private System.Windows.Forms.GroupBox mainRandom;
-        private System.Windows.Forms.FlowLayoutPanel mainRandomPanel;
+        private System.Windows.Forms.GroupBox pc98Random;
+        private System.Windows.Forms.FlowLayoutPanel pc98RandomPanel;
         private System.Windows.Forms.CheckBox chkHRtP;
         private System.Windows.Forms.CheckBox chkSoEW;
         private System.Windows.Forms.CheckBox chkPoDD;
@@ -2666,41 +2737,19 @@
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.ContextMenuStrip trayMenu;
-        private System.Windows.Forms.ToolStripMenuItem trayMain;
+        private System.Windows.Forms.ToolStripMenuItem trayPC98;
         private System.Windows.Forms.ToolStripMenuItem trayHRtP;
         private System.Windows.Forms.ToolStripMenuItem traySoEW;
         private System.Windows.Forms.ToolStripMenuItem trayPoDD;
         private System.Windows.Forms.ToolStripMenuItem trayLLS;
         private System.Windows.Forms.ToolStripMenuItem trayMS;
-        private System.Windows.Forms.ToolStripMenuItem trayEoSD;
-        private System.Windows.Forms.ToolStripMenuItem trayPCB;
-        private System.Windows.Forms.ToolStripMenuItem trayIN;
-        private System.Windows.Forms.ToolStripMenuItem trayPoFV;
-        private System.Windows.Forms.ToolStripMenuItem trayMoF;
-        private System.Windows.Forms.ToolStripMenuItem traySA;
-        private System.Windows.Forms.ToolStripMenuItem trayUFO;
-        private System.Windows.Forms.ToolStripMenuItem trayTD;
-        private System.Windows.Forms.ToolStripMenuItem trayDDC;
-        private System.Windows.Forms.ToolStripMenuItem trayLoLK;
-        private System.Windows.Forms.ToolStripMenuItem trayHSiFS;
-        private System.Windows.Forms.ToolStripMenuItem trayFighting;
-        private System.Windows.Forms.ToolStripMenuItem trayOther;
+        private System.Windows.Forms.ToolStripMenuItem trayMain;
+        private System.Windows.Forms.ToolStripMenuItem trayTasofro;
         private System.Windows.Forms.ToolStripMenuItem trayCustom;
         private System.Windows.Forms.ToolStripMenuItem trayRandom;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem trayOpen;
         private System.Windows.Forms.ToolStripMenuItem trayExit;
-        private System.Windows.Forms.ToolStripMenuItem trayIaMP;
-        private System.Windows.Forms.ToolStripMenuItem traySWR;
-        private System.Windows.Forms.ToolStripMenuItem trayUoNL;
-        private System.Windows.Forms.ToolStripMenuItem trayHM;
-        private System.Windows.Forms.ToolStripMenuItem trayULiL;
-        private System.Windows.Forms.ToolStripMenuItem trayAoCF;
-        private System.Windows.Forms.ToolStripMenuItem trayStB;
-        private System.Windows.Forms.ToolStripMenuItem trayDS;
-        private System.Windows.Forms.ToolStripMenuItem trayGFW;
-        private System.Windows.Forms.ToolStripMenuItem trayISC;
-        private System.Windows.Forms.ToolStripMenuItem trayVD;
         private System.Windows.Forms.Label label4;
         public System.Windows.Forms.ToolTip toolTip;
         private System.Windows.Forms.NotifyIcon trayIcon;
@@ -2719,16 +2768,43 @@
         private System.Windows.Forms.ToolStripMenuItem bannerToolStripMenuItem;
         private System.Windows.Forms.Button btnWBaWC;
         private System.Windows.Forms.CheckBox chkWBaWC;
-        private System.Windows.Forms.ToolStripMenuItem trayWBaWC;
         private System.Windows.Forms.Button btnUM;
         private System.Windows.Forms.CheckBox chkUM;
-        private System.Windows.Forms.ToolStripMenuItem trayUM;
         private System.Windows.Forms.CheckBox chkGI;
         private System.Windows.Forms.Button btnGI;
         private System.Windows.Forms.ToolStripMenuItem trayGI;
         private System.Windows.Forms.Button btnHBM;
-        private System.Windows.Forms.ToolStripMenuItem trayHBM;
         private System.Windows.Forms.CheckBox chkHBM;
+        private System.Windows.Forms.ToolStripMenuItem trayEoSD;
+        private System.Windows.Forms.ToolStripMenuItem trayPCB;
+        private System.Windows.Forms.ToolStripMenuItem trayIN;
+        private System.Windows.Forms.ToolStripMenuItem trayPoFV;
+        private System.Windows.Forms.ToolStripMenuItem trayMoF;
+        private System.Windows.Forms.ToolStripMenuItem traySA;
+        private System.Windows.Forms.ToolStripMenuItem trayUFO;
+        private System.Windows.Forms.ToolStripMenuItem trayTD;
+        private System.Windows.Forms.ToolStripMenuItem trayDDC;
+        private System.Windows.Forms.ToolStripMenuItem trayLoLK;
+        private System.Windows.Forms.ToolStripMenuItem trayHSiFS;
+        private System.Windows.Forms.ToolStripMenuItem trayWBaWC;
+        private System.Windows.Forms.ToolStripMenuItem trayUM;
+        private System.Windows.Forms.ToolStripMenuItem trayIaMP;
+        private System.Windows.Forms.ToolStripMenuItem traySWR;
+        private System.Windows.Forms.ToolStripMenuItem trayUoNL;
+        private System.Windows.Forms.ToolStripMenuItem trayHM;
+        private System.Windows.Forms.ToolStripMenuItem trayULiL;
+        private System.Windows.Forms.ToolStripMenuItem trayAoCF;
+        private System.Windows.Forms.GroupBox spinoffGroup;
+        private System.Windows.Forms.FlowLayoutPanel spinoffLayoutPanel;
+        private System.Windows.Forms.GroupBox spinoffRandom;
+        private System.Windows.Forms.FlowLayoutPanel spinoffRandomPanel;
+        private System.Windows.Forms.ToolStripMenuItem traySpinoff;
+        private System.Windows.Forms.ToolStripMenuItem trayStB;
+        private System.Windows.Forms.ToolStripMenuItem trayDS;
+        private System.Windows.Forms.ToolStripMenuItem trayGFW;
+        private System.Windows.Forms.ToolStripMenuItem trayISC;
+        private System.Windows.Forms.ToolStripMenuItem trayVD;
+        private System.Windows.Forms.ToolStripMenuItem trayHBM;
     }
 }
 

--- a/Touhou Launcher/MainForm.Designer.cs
+++ b/Touhou Launcher/MainForm.Designer.cs
@@ -131,8 +131,7 @@
             this.replayPanel = new System.Windows.Forms.Panel();
             this.linkReplays = new System.Windows.Forms.TextBox();
             this.appspotReplays = new System.Windows.Forms.RadioButton();
-            this.royalflareReplays = new System.Windows.Forms.RadioButton();
-            this.gensokyoReplays = new System.Windows.Forms.RadioButton();
+            this.maribelReplays = new System.Windows.Forms.RadioButton();
             this.customGames = new System.Windows.Forms.TabPage();
             this.customAdd = new System.Windows.Forms.Button();
             this.customList = new System.Windows.Forms.ListView();
@@ -626,9 +625,9 @@
             this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 14F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label1.Location = new System.Drawing.Point(9, 16);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(192, 24);
+            this.label1.Size = new System.Drawing.Size(202, 24);
             this.label1.TabIndex = 0;
-            this.label1.Text = "Touhou Launcher 1.0";
+            this.label1.Text = "Touhou Launcher 1.01";
             // 
             // settings
             // 
@@ -1380,8 +1379,7 @@
             this.replayPanel.BackColor = System.Drawing.Color.Transparent;
             this.replayPanel.Controls.Add(this.linkReplays);
             this.replayPanel.Controls.Add(this.appspotReplays);
-            this.replayPanel.Controls.Add(this.royalflareReplays);
-            this.replayPanel.Controls.Add(this.gensokyoReplays);
+            this.replayPanel.Controls.Add(this.maribelReplays);
             this.replayPanel.Location = new System.Drawing.Point(0, 0);
             this.replayPanel.Name = "replayPanel";
             this.replayPanel.Size = new System.Drawing.Size(518, 29);
@@ -1389,9 +1387,9 @@
             // 
             // linkReplays
             // 
-            this.linkReplays.Location = new System.Drawing.Point(406, 3);
+            this.linkReplays.Location = new System.Drawing.Point(241, 3);
             this.linkReplays.Name = "linkReplays";
-            this.linkReplays.Size = new System.Drawing.Size(109, 20);
+            this.linkReplays.Size = new System.Drawing.Size(274, 20);
             this.linkReplays.TabIndex = 3;
             this.linkReplays.KeyDown += new System.Windows.Forms.KeyEventHandler(this.linkReplays_KeyDown);
             // 
@@ -1400,7 +1398,7 @@
             this.appspotReplays.Appearance = System.Windows.Forms.Appearance.Button;
             this.appspotReplays.AutoSize = true;
             this.appspotReplays.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.appspotReplays.Location = new System.Drawing.Point(277, 3);
+            this.appspotReplays.Location = new System.Drawing.Point(112, 3);
             this.appspotReplays.Name = "appspotReplays";
             this.appspotReplays.Size = new System.Drawing.Size(123, 23);
             this.appspotReplays.TabIndex = 2;
@@ -1409,34 +1407,20 @@
             this.appspotReplays.UseVisualStyleBackColor = true;
             this.appspotReplays.CheckedChanged += new System.EventHandler(this.Replays_CheckedChanged);
             // 
-            // royalflareReplays
+            // maribelReplays
             // 
-            this.royalflareReplays.Appearance = System.Windows.Forms.Appearance.Button;
-            this.royalflareReplays.AutoSize = true;
-            this.royalflareReplays.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.royalflareReplays.Location = new System.Drawing.Point(163, 3);
-            this.royalflareReplays.Name = "royalflareReplays";
-            this.royalflareReplays.Size = new System.Drawing.Size(108, 23);
-            this.royalflareReplays.TabIndex = 1;
-            this.royalflareReplays.Text = "replay.royalflare.net";
-            this.royalflareReplays.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            this.royalflareReplays.UseVisualStyleBackColor = true;
-            this.royalflareReplays.CheckedChanged += new System.EventHandler(this.Replays_CheckedChanged);
-            // 
-            // gensokyoReplays
-            // 
-            this.gensokyoReplays.Appearance = System.Windows.Forms.Appearance.Button;
-            this.gensokyoReplays.AutoSize = true;
-            this.gensokyoReplays.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.gensokyoReplays.Location = new System.Drawing.Point(6, 3);
-            this.gensokyoReplays.Name = "gensokyoReplays";
-            this.gensokyoReplays.Size = new System.Drawing.Size(151, 23);
-            this.gensokyoReplays.TabIndex = 0;
-            this.gensokyoReplays.TabStop = true;
-            this.gensokyoReplays.Text = "maribelhearn.com/gensokyo";
-            this.gensokyoReplays.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            this.gensokyoReplays.UseVisualStyleBackColor = true;
-            this.gensokyoReplays.CheckedChanged += new System.EventHandler(this.Replays_CheckedChanged);
+            this.maribelReplays.Appearance = System.Windows.Forms.Appearance.Button;
+            this.maribelReplays.AutoSize = true;
+            this.maribelReplays.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.maribelReplays.Location = new System.Drawing.Point(6, 3);
+            this.maribelReplays.Name = "maribelReplays";
+            this.maribelReplays.Size = new System.Drawing.Size(100, 23);
+            this.maribelReplays.TabIndex = 0;
+            this.maribelReplays.TabStop = true;
+            this.maribelReplays.Text = "maribelhearn.com";
+            this.maribelReplays.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.maribelReplays.UseVisualStyleBackColor = true;
+            this.maribelReplays.CheckedChanged += new System.EventHandler(this.Replays_CheckedChanged);
             // 
             // customGames
             // 
@@ -2545,8 +2529,7 @@
         private System.Windows.Forms.WebBrowser replayBrowser;
         private System.Windows.Forms.Panel replayPanel;
         private System.Windows.Forms.RadioButton appspotReplays;
-        private System.Windows.Forms.RadioButton royalflareReplays;
-        private System.Windows.Forms.RadioButton gensokyoReplays;
+        private System.Windows.Forms.RadioButton maribelReplays;
         private System.Windows.Forms.TabPage customGames;
         private System.Windows.Forms.Button customAdd;
         private System.Windows.Forms.ListView customList;

--- a/Touhou Launcher/MainForm.Designer.cs
+++ b/Touhou Launcher/MainForm.Designer.cs
@@ -82,6 +82,7 @@
             this.chkGFW = new System.Windows.Forms.CheckBox();
             this.chkISC = new System.Windows.Forms.CheckBox();
             this.chkVD = new System.Windows.Forms.CheckBox();
+            this.chkGI = new System.Windows.Forms.CheckBox();
             this.fightingRandom = new System.Windows.Forms.GroupBox();
             this.fightingRandomPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.chkIaMP = new System.Windows.Forms.CheckBox();
@@ -146,6 +147,7 @@
             this.btnGFW = new System.Windows.Forms.Button();
             this.btnISC = new System.Windows.Forms.Button();
             this.btnVD = new System.Windows.Forms.Button();
+            this.btnGI = new System.Windows.Forms.Button();
             this.fightingGroup = new System.Windows.Forms.GroupBox();
             this.fightingLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.btnIaMP = new System.Windows.Forms.Button();
@@ -188,6 +190,7 @@
             this.trayLoLK = new System.Windows.Forms.ToolStripMenuItem();
             this.trayHSiFS = new System.Windows.Forms.ToolStripMenuItem();
             this.trayWBaWC = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayUM = new System.Windows.Forms.ToolStripMenuItem();
             this.trayFighting = new System.Windows.Forms.ToolStripMenuItem();
             this.trayIaMP = new System.Windows.Forms.ToolStripMenuItem();
             this.traySWR = new System.Windows.Forms.ToolStripMenuItem();
@@ -201,13 +204,13 @@
             this.trayGFW = new System.Windows.Forms.ToolStripMenuItem();
             this.trayISC = new System.Windows.Forms.ToolStripMenuItem();
             this.trayVD = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayGI = new System.Windows.Forms.ToolStripMenuItem();
             this.trayCustom = new System.Windows.Forms.ToolStripMenuItem();
             this.trayRandom = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             this.trayOpen = new System.Windows.Forms.ToolStripMenuItem();
             this.trayExit = new System.Windows.Forms.ToolStripMenuItem();
             this.trayIcon = new System.Windows.Forms.NotifyIcon(this.components);
-            this.trayUM = new System.Windows.Forms.ToolStripMenuItem();
             this.gameContextMenu.SuspendLayout();
             this.customContextMenu.SuspendLayout();
             this.customFolderContextMenu.SuspendLayout();
@@ -710,6 +713,7 @@
             this.miscRandomPanel.Controls.Add(this.chkGFW);
             this.miscRandomPanel.Controls.Add(this.chkISC);
             this.miscRandomPanel.Controls.Add(this.chkVD);
+            this.miscRandomPanel.Controls.Add(this.chkGI);
             this.miscRandomPanel.Location = new System.Drawing.Point(3, 16);
             this.miscRandomPanel.Margin = new System.Windows.Forms.Padding(0);
             this.miscRandomPanel.Name = "miscRandomPanel";
@@ -780,6 +784,19 @@
             this.chkVD.Text = "VD";
             this.chkVD.UseVisualStyleBackColor = true;
             this.chkVD.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkGI
+            // 
+            this.chkGI.AutoSize = true;
+            this.chkGI.Checked = true;
+            this.chkGI.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkGI.Location = new System.Drawing.Point(3, 26);
+            this.chkGI.Name = "chkGI";
+            this.chkGI.Size = new System.Drawing.Size(37, 17);
+            this.chkGI.TabIndex = 5;
+            this.chkGI.Text = "GI";
+            this.chkGI.UseVisualStyleBackColor = true;
+            this.chkGI.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
             // 
             // fightingRandom
             // 
@@ -1545,6 +1562,7 @@
             this.miscLayoutPanel.Controls.Add(this.btnGFW);
             this.miscLayoutPanel.Controls.Add(this.btnISC);
             this.miscLayoutPanel.Controls.Add(this.btnVD);
+            this.miscLayoutPanel.Controls.Add(this.btnGI);
             this.miscLayoutPanel.Location = new System.Drawing.Point(3, 16);
             this.miscLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
             this.miscLayoutPanel.Name = "miscLayoutPanel";
@@ -1639,6 +1657,24 @@
             this.btnVD.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnVD.UseVisualStyleBackColor = true;
             this.btnVD.Click += new System.EventHandler(this.btn_Click);
+            // 
+            // btnGI
+            // 
+            this.btnGI.BackgroundImage = global::Touhou_Launcher.Properties.Resources.gig;
+            this.btnGI.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btnGI.ContextMenuStrip = this.gameContextMenu;
+            this.btnGI.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btnGI.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.btnGI.ForeColor = System.Drawing.SystemColors.Window;
+            this.btnGI.Location = new System.Drawing.Point(129, 53);
+            this.btnGI.Name = "btnGI";
+            this.btnGI.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
+            this.btnGI.Size = new System.Drawing.Size(120, 44);
+            this.btnGI.TabIndex = 5;
+            this.btnGI.Text = "Gouyoku Ibun";
+            this.btnGI.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btnGI.UseVisualStyleBackColor = true;
+            this.btnGI.Click += new System.EventHandler(this.btn_Click);
             // 
             // fightingGroup
             // 
@@ -2248,6 +2284,15 @@
             this.trayWBaWC.Text = "Wily Beast and Weakest Creature";
             this.trayWBaWC.Click += new System.EventHandler(this.tray_Click);
             // 
+            // trayUM
+            // 
+            this.trayUM.Image = global::Touhou_Launcher.Properties.Resources.Icon_th18;
+            this.trayUM.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayUM.Name = "trayUM";
+            this.trayUM.Size = new System.Drawing.Size(262, 38);
+            this.trayUM.Text = "Unconnected Marketeers";
+            this.trayUM.Click += new System.EventHandler(this.tray_Click);
+            // 
             // trayFighting
             // 
             this.trayFighting.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -2322,7 +2367,8 @@
             this.trayDS,
             this.trayGFW,
             this.trayISC,
-            this.trayVD});
+            this.trayVD,
+            this.trayGI});
             this.trayOther.Name = "trayOther";
             this.trayOther.Size = new System.Drawing.Size(157, 22);
             this.trayOther.Text = "Other Games";
@@ -2372,6 +2418,15 @@
             this.trayVD.Text = "Violet Detector";
             this.trayVD.Click += new System.EventHandler(this.tray_Click);
             // 
+            // trayGI
+            // 
+            this.trayGI.Image = global::Touhou_Launcher.Properties.Resources.Icon_th175;
+            this.trayGI.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayGI.Name = "trayGI";
+            this.trayGI.Size = new System.Drawing.Size(203, 38);
+            this.trayGI.Text = "Gouyoku Ibun";
+            this.trayGI.Click += new System.EventHandler(this.tray_Click);
+            // 
             // trayCustom
             // 
             this.trayCustom.Name = "trayCustom";
@@ -2410,15 +2465,6 @@
             this.trayIcon.Icon = global::Touhou_Launcher.Properties.Resources.thicon;
             this.trayIcon.Text = "Touhou Launcher";
             this.trayIcon.DoubleClick += new System.EventHandler(this.MainForm_Show);
-            // 
-            // trayUM
-            // 
-            this.trayUM.Image = global::Touhou_Launcher.Properties.Resources.Icon_th18;
-            this.trayUM.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayUM.Name = "trayUM";
-            this.trayUM.Size = new System.Drawing.Size(262, 38);
-            this.trayUM.Text = "Unconnected Marketeers";
-            this.trayUM.Click += new System.EventHandler(this.tray_Click);
             // 
             // MainForm
             // 
@@ -2648,6 +2694,9 @@
         private System.Windows.Forms.Button btnUM;
         private System.Windows.Forms.CheckBox chkUM;
         private System.Windows.Forms.ToolStripMenuItem trayUM;
+        private System.Windows.Forms.CheckBox chkGI;
+        private System.Windows.Forms.Button btnGI;
+        private System.Windows.Forms.ToolStripMenuItem trayGI;
     }
 }
 

--- a/Touhou Launcher/MainForm.Designer.cs
+++ b/Touhou Launcher/MainForm.Designer.cs
@@ -72,32 +72,28 @@
             this.label1 = new System.Windows.Forms.Label();
             this.settings = new System.Windows.Forms.TabPage();
             this.randomSettings = new System.Windows.Forms.GroupBox();
-            this.randomLabel = new System.Windows.Forms.Label();
-            this.randomNone = new System.Windows.Forms.Button();
-            this.randomAll = new System.Windows.Forms.Button();
-            this.otherRandom = new System.Windows.Forms.GroupBox();
-            this.miscRandomPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.spinoffRandom = new System.Windows.Forms.GroupBox();
+            this.spinoffRandomPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.chkStB = new System.Windows.Forms.CheckBox();
             this.chkDS = new System.Windows.Forms.CheckBox();
             this.chkGFW = new System.Windows.Forms.CheckBox();
             this.chkISC = new System.Windows.Forms.CheckBox();
             this.chkVD = new System.Windows.Forms.CheckBox();
-            this.chkGI = new System.Windows.Forms.CheckBox();
-            this.fightingRandom = new System.Windows.Forms.GroupBox();
-            this.fightingRandomPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.chkHBM = new System.Windows.Forms.CheckBox();
+            this.randomLabel = new System.Windows.Forms.Label();
+            this.randomNone = new System.Windows.Forms.Button();
+            this.randomAll = new System.Windows.Forms.Button();
+            this.tasofroRandom = new System.Windows.Forms.GroupBox();
+            this.tasofroRandomPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.chkIaMP = new System.Windows.Forms.CheckBox();
             this.chkSWR = new System.Windows.Forms.CheckBox();
             this.chkUoNL = new System.Windows.Forms.CheckBox();
             this.chkHM = new System.Windows.Forms.CheckBox();
             this.chkULiL = new System.Windows.Forms.CheckBox();
             this.chkAoCF = new System.Windows.Forms.CheckBox();
+            this.chkGI = new System.Windows.Forms.CheckBox();
             this.mainRandom = new System.Windows.Forms.GroupBox();
             this.mainRandomPanel = new System.Windows.Forms.FlowLayoutPanel();
-            this.chkHRtP = new System.Windows.Forms.CheckBox();
-            this.chkSoEW = new System.Windows.Forms.CheckBox();
-            this.chkPoDD = new System.Windows.Forms.CheckBox();
-            this.chkLLS = new System.Windows.Forms.CheckBox();
-            this.chkMS = new System.Windows.Forms.CheckBox();
             this.chkEoSD = new System.Windows.Forms.CheckBox();
             this.chkPCB = new System.Windows.Forms.CheckBox();
             this.chkIN = new System.Windows.Forms.CheckBox();
@@ -111,6 +107,13 @@
             this.chkHSiFS = new System.Windows.Forms.CheckBox();
             this.chkWBaWC = new System.Windows.Forms.CheckBox();
             this.chkUM = new System.Windows.Forms.CheckBox();
+            this.pc98Random = new System.Windows.Forms.GroupBox();
+            this.pc98RandomPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.chkHRtP = new System.Windows.Forms.CheckBox();
+            this.chkSoEW = new System.Windows.Forms.CheckBox();
+            this.chkPoDD = new System.Windows.Forms.CheckBox();
+            this.chkLLS = new System.Windows.Forms.CheckBox();
+            this.chkMS = new System.Windows.Forms.CheckBox();
             this.launcherSettings = new System.Windows.Forms.GroupBox();
             this.crapResetStartingRepo = new System.Windows.Forms.Button();
             this.crapStartingRepo = new System.Windows.Forms.TextBox();
@@ -139,22 +142,23 @@
             this.customTree = new System.Windows.Forms.TreeView();
             this.mainControl = new System.Windows.Forms.TabControl();
             this.games = new System.Windows.Forms.TabPage();
-            this.otherGroup = new System.Windows.Forms.GroupBox();
-            this.miscLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.spinoffGroup = new System.Windows.Forms.GroupBox();
+            this.spinoffLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.btnStB = new System.Windows.Forms.Button();
             this.btnDS = new System.Windows.Forms.Button();
             this.btnGFW = new System.Windows.Forms.Button();
             this.btnISC = new System.Windows.Forms.Button();
             this.btnVD = new System.Windows.Forms.Button();
-            this.btnGI = new System.Windows.Forms.Button();
-            this.fightingGroup = new System.Windows.Forms.GroupBox();
-            this.fightingLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.btnHBM = new System.Windows.Forms.Button();
+            this.tasofroGroup = new System.Windows.Forms.GroupBox();
+            this.tasofroLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.btnIaMP = new System.Windows.Forms.Button();
             this.btnSWR = new System.Windows.Forms.Button();
             this.btnUoNL = new System.Windows.Forms.Button();
             this.btnHM = new System.Windows.Forms.Button();
             this.btnULiL = new System.Windows.Forms.Button();
             this.btnAoCF = new System.Windows.Forms.Button();
+            this.btnGI = new System.Windows.Forms.Button();
             this.mainGroup = new System.Windows.Forms.GroupBox();
             this.mainLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.btnEoSD = new System.Windows.Forms.Button();
@@ -170,13 +174,16 @@
             this.btnHSiFS = new System.Windows.Forms.Button();
             this.btnWBaWC = new System.Windows.Forms.Button();
             this.btnUM = new System.Windows.Forms.Button();
+            this.pc98Group = new System.Windows.Forms.GroupBox();
+            this.pc98LayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.trayMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.trayMain = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayPC98 = new System.Windows.Forms.ToolStripMenuItem();
             this.trayHRtP = new System.Windows.Forms.ToolStripMenuItem();
             this.traySoEW = new System.Windows.Forms.ToolStripMenuItem();
             this.trayPoDD = new System.Windows.Forms.ToolStripMenuItem();
             this.trayLLS = new System.Windows.Forms.ToolStripMenuItem();
             this.trayMS = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayMain = new System.Windows.Forms.ToolStripMenuItem();
             this.trayEoSD = new System.Windows.Forms.ToolStripMenuItem();
             this.trayPCB = new System.Windows.Forms.ToolStripMenuItem();
             this.trayIN = new System.Windows.Forms.ToolStripMenuItem();
@@ -190,19 +197,20 @@
             this.trayHSiFS = new System.Windows.Forms.ToolStripMenuItem();
             this.trayWBaWC = new System.Windows.Forms.ToolStripMenuItem();
             this.trayUM = new System.Windows.Forms.ToolStripMenuItem();
-            this.trayFighting = new System.Windows.Forms.ToolStripMenuItem();
+            this.traySpinoff = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayStB = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayDS = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayGFW = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayISC = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayVD = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayHBM = new System.Windows.Forms.ToolStripMenuItem();
+            this.trayTasofro = new System.Windows.Forms.ToolStripMenuItem();
             this.trayIaMP = new System.Windows.Forms.ToolStripMenuItem();
             this.traySWR = new System.Windows.Forms.ToolStripMenuItem();
             this.trayUoNL = new System.Windows.Forms.ToolStripMenuItem();
             this.trayHM = new System.Windows.Forms.ToolStripMenuItem();
             this.trayULiL = new System.Windows.Forms.ToolStripMenuItem();
             this.trayAoCF = new System.Windows.Forms.ToolStripMenuItem();
-            this.trayOther = new System.Windows.Forms.ToolStripMenuItem();
-            this.trayStB = new System.Windows.Forms.ToolStripMenuItem();
-            this.trayDS = new System.Windows.Forms.ToolStripMenuItem();
-            this.trayGFW = new System.Windows.Forms.ToolStripMenuItem();
-            this.trayISC = new System.Windows.Forms.ToolStripMenuItem();
-            this.trayVD = new System.Windows.Forms.ToolStripMenuItem();
             this.trayGI = new System.Windows.Forms.ToolStripMenuItem();
             this.trayCustom = new System.Windows.Forms.ToolStripMenuItem();
             this.trayRandom = new System.Windows.Forms.ToolStripMenuItem();
@@ -210,33 +218,34 @@
             this.trayOpen = new System.Windows.Forms.ToolStripMenuItem();
             this.trayExit = new System.Windows.Forms.ToolStripMenuItem();
             this.trayIcon = new System.Windows.Forms.NotifyIcon(this.components);
-            this.btnHBM = new System.Windows.Forms.Button();
-            this.trayHBM = new System.Windows.Forms.ToolStripMenuItem();
-            this.chkHBM = new System.Windows.Forms.CheckBox();
             this.gameContextMenu.SuspendLayout();
             this.customContextMenu.SuspendLayout();
             this.customFolderContextMenu.SuspendLayout();
             this.info.SuspendLayout();
             this.settings.SuspendLayout();
             this.randomSettings.SuspendLayout();
-            this.otherRandom.SuspendLayout();
-            this.miscRandomPanel.SuspendLayout();
-            this.fightingRandom.SuspendLayout();
-            this.fightingRandomPanel.SuspendLayout();
+            this.spinoffRandom.SuspendLayout();
+            this.spinoffRandomPanel.SuspendLayout();
+            this.tasofroRandom.SuspendLayout();
+            this.tasofroRandomPanel.SuspendLayout();
             this.mainRandom.SuspendLayout();
             this.mainRandomPanel.SuspendLayout();
+            this.pc98Random.SuspendLayout();
+            this.pc98RandomPanel.SuspendLayout();
             this.launcherSettings.SuspendLayout();
             this.replays.SuspendLayout();
             this.replayPanel.SuspendLayout();
             this.customGames.SuspendLayout();
             this.mainControl.SuspendLayout();
             this.games.SuspendLayout();
-            this.otherGroup.SuspendLayout();
-            this.miscLayoutPanel.SuspendLayout();
-            this.fightingGroup.SuspendLayout();
-            this.fightingLayoutPanel.SuspendLayout();
+            this.spinoffGroup.SuspendLayout();
+            this.spinoffLayoutPanel.SuspendLayout();
+            this.tasofroGroup.SuspendLayout();
+            this.tasofroLayoutPanel.SuspendLayout();
             this.mainGroup.SuspendLayout();
             this.mainLayoutPanel.SuspendLayout();
+            this.pc98Group.SuspendLayout();
+            this.pc98LayoutPanel.SuspendLayout();
             this.trayMenu.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -486,7 +495,7 @@
             this.btnSoEW.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnSoEW.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnSoEW.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnSoEW.Location = new System.Drawing.Point(129, 3);
+            this.btnSoEW.Location = new System.Drawing.Point(3, 53);
             this.btnSoEW.Name = "btnSoEW";
             this.btnSoEW.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnSoEW.Size = new System.Drawing.Size(120, 44);
@@ -504,11 +513,11 @@
             this.btnRandom.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnRandom.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnRandom.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnRandom.Location = new System.Drawing.Point(204, 538);
+            this.btnRandom.Location = new System.Drawing.Point(208, 510);
             this.btnRandom.Name = "btnRandom";
             this.btnRandom.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnRandom.Size = new System.Drawing.Size(120, 44);
-            this.btnRandom.TabIndex = 4;
+            this.btnRandom.TabIndex = 5;
             this.btnRandom.Text = "Random";
             this.btnRandom.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnRandom.UseVisualStyleBackColor = true;
@@ -522,7 +531,7 @@
             this.btnPoDD.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnPoDD.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnPoDD.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnPoDD.Location = new System.Drawing.Point(255, 3);
+            this.btnPoDD.Location = new System.Drawing.Point(3, 103);
             this.btnPoDD.Name = "btnPoDD";
             this.btnPoDD.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnPoDD.Size = new System.Drawing.Size(120, 44);
@@ -540,7 +549,7 @@
             this.btnLLS.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnLLS.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnLLS.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnLLS.Location = new System.Drawing.Point(381, 3);
+            this.btnLLS.Location = new System.Drawing.Point(3, 153);
             this.btnLLS.Name = "btnLLS";
             this.btnLLS.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnLLS.Size = new System.Drawing.Size(120, 44);
@@ -558,7 +567,7 @@
             this.btnMS.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnMS.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnMS.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnMS.Location = new System.Drawing.Point(3, 53);
+            this.btnMS.Location = new System.Drawing.Point(3, 203);
             this.btnMS.Name = "btnMS";
             this.btnMS.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnMS.Size = new System.Drawing.Size(120, 44);
@@ -579,7 +588,7 @@
             this.info.Location = new System.Drawing.Point(4, 22);
             this.info.Name = "info";
             this.info.Padding = new System.Windows.Forms.Padding(3);
-            this.info.Size = new System.Drawing.Size(527, 585);
+            this.info.Size = new System.Drawing.Size(537, 555);
             this.info.TabIndex = 5;
             this.info.Text = "Info";
             // 
@@ -630,7 +639,7 @@
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(202, 24);
             this.label1.TabIndex = 0;
-            this.label1.Text = "Touhou Launcher 1.01";
+            this.label1.Text = "Touhou Launcher 1.02";
             // 
             // settings
             // 
@@ -640,7 +649,7 @@
             this.settings.Location = new System.Drawing.Point(4, 22);
             this.settings.Name = "settings";
             this.settings.Padding = new System.Windows.Forms.Padding(3);
-            this.settings.Size = new System.Drawing.Size(527, 585);
+            this.settings.Size = new System.Drawing.Size(537, 555);
             this.settings.TabIndex = 4;
             this.settings.Text = "Settings";
             // 
@@ -648,80 +657,49 @@
             // 
             this.randomSettings.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.randomSettings.Controls.Add(this.spinoffRandom);
             this.randomSettings.Controls.Add(this.randomLabel);
             this.randomSettings.Controls.Add(this.randomNone);
             this.randomSettings.Controls.Add(this.randomAll);
-            this.randomSettings.Controls.Add(this.otherRandom);
-            this.randomSettings.Controls.Add(this.fightingRandom);
+            this.randomSettings.Controls.Add(this.tasofroRandom);
             this.randomSettings.Controls.Add(this.mainRandom);
+            this.randomSettings.Controls.Add(this.pc98Random);
             this.randomSettings.Location = new System.Drawing.Point(214, 8);
             this.randomSettings.Name = "randomSettings";
-            this.randomSettings.Size = new System.Drawing.Size(307, 370);
+            this.randomSettings.Size = new System.Drawing.Size(317, 370);
             this.randomSettings.TabIndex = 2;
             this.randomSettings.TabStop = false;
             this.randomSettings.Text = "Random Game Settings";
             // 
-            // randomLabel
+            // spinoffRandom
             // 
-            this.randomLabel.Anchor = System.Windows.Forms.AnchorStyles.Top;
-            this.randomLabel.Location = new System.Drawing.Point(48, 16);
-            this.randomLabel.Name = "randomLabel";
-            this.randomLabel.Size = new System.Drawing.Size(211, 29);
-            this.randomLabel.TabIndex = 4;
-            this.randomLabel.Text = "Games that will be included in the\r\nrandom game option:";
-            this.randomLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // randomNone
-            // 
-            this.randomNone.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.randomNone.Location = new System.Drawing.Point(211, 49);
-            this.randomNone.Name = "randomNone";
-            this.randomNone.Size = new System.Drawing.Size(90, 25);
-            this.randomNone.TabIndex = 1;
-            this.randomNone.Text = "Select None";
-            this.randomNone.UseVisualStyleBackColor = true;
-            this.randomNone.Click += new System.EventHandler(this.randomNone_Click);
-            // 
-            // randomAll
-            // 
-            this.randomAll.Location = new System.Drawing.Point(6, 49);
-            this.randomAll.Name = "randomAll";
-            this.randomAll.Size = new System.Drawing.Size(90, 25);
-            this.randomAll.TabIndex = 0;
-            this.randomAll.Text = "Select All";
-            this.randomAll.UseVisualStyleBackColor = true;
-            this.randomAll.Click += new System.EventHandler(this.randomAll_Click);
-            // 
-            // otherRandom
-            // 
-            this.otherRandom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.spinoffRandom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.otherRandom.Controls.Add(this.miscRandomPanel);
-            this.otherRandom.Location = new System.Drawing.Point(6, 298);
-            this.otherRandom.Name = "otherRandom";
-            this.otherRandom.Size = new System.Drawing.Size(295, 66);
-            this.otherRandom.TabIndex = 4;
-            this.otherRandom.TabStop = false;
-            this.otherRandom.Text = "Other Games";
+            this.spinoffRandom.Controls.Add(this.spinoffRandomPanel);
+            this.spinoffRandom.Location = new System.Drawing.Point(6, 224);
+            this.spinoffRandom.Name = "spinoffRandom";
+            this.spinoffRandom.Size = new System.Drawing.Size(305, 68);
+            this.spinoffRandom.TabIndex = 4;
+            this.spinoffRandom.TabStop = false;
+            this.spinoffRandom.Text = "Spinoffs";
             // 
-            // miscRandomPanel
+            // spinoffRandomPanel
             // 
-            this.miscRandomPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.spinoffRandomPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.miscRandomPanel.AutoScroll = true;
-            this.miscRandomPanel.Controls.Add(this.chkStB);
-            this.miscRandomPanel.Controls.Add(this.chkDS);
-            this.miscRandomPanel.Controls.Add(this.chkGFW);
-            this.miscRandomPanel.Controls.Add(this.chkISC);
-            this.miscRandomPanel.Controls.Add(this.chkVD);
-            this.miscRandomPanel.Controls.Add(this.chkGI);
-            this.miscRandomPanel.Controls.Add(this.chkHBM);
-            this.miscRandomPanel.Location = new System.Drawing.Point(3, 16);
-            this.miscRandomPanel.Margin = new System.Windows.Forms.Padding(0);
-            this.miscRandomPanel.Name = "miscRandomPanel";
-            this.miscRandomPanel.Size = new System.Drawing.Size(289, 47);
-            this.miscRandomPanel.TabIndex = 1;
+            this.spinoffRandomPanel.AutoScroll = true;
+            this.spinoffRandomPanel.Controls.Add(this.chkStB);
+            this.spinoffRandomPanel.Controls.Add(this.chkDS);
+            this.spinoffRandomPanel.Controls.Add(this.chkGFW);
+            this.spinoffRandomPanel.Controls.Add(this.chkISC);
+            this.spinoffRandomPanel.Controls.Add(this.chkVD);
+            this.spinoffRandomPanel.Controls.Add(this.chkHBM);
+            this.spinoffRandomPanel.Location = new System.Drawing.Point(3, 16);
+            this.spinoffRandomPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.spinoffRandomPanel.Name = "spinoffRandomPanel";
+            this.spinoffRandomPanel.Size = new System.Drawing.Size(299, 49);
+            this.spinoffRandomPanel.TabIndex = 1;
             // 
             // chkStB
             // 
@@ -788,48 +766,80 @@
             this.chkVD.UseVisualStyleBackColor = true;
             this.chkVD.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
             // 
-            // chkGI
+            // chkHBM
             // 
-            this.chkGI.AutoSize = true;
-            this.chkGI.Checked = true;
-            this.chkGI.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkGI.Location = new System.Drawing.Point(3, 26);
-            this.chkGI.Name = "chkGI";
-            this.chkGI.Size = new System.Drawing.Size(37, 17);
-            this.chkGI.TabIndex = 5;
-            this.chkGI.Text = "GI";
-            this.chkGI.UseVisualStyleBackColor = true;
-            this.chkGI.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            this.chkHBM.AutoSize = true;
+            this.chkHBM.Checked = true;
+            this.chkHBM.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkHBM.Location = new System.Drawing.Point(3, 26);
+            this.chkHBM.Name = "chkHBM";
+            this.chkHBM.Size = new System.Drawing.Size(60, 17);
+            this.chkHBM.TabIndex = 18;
+            this.chkHBM.Text = "100BM";
+            this.chkHBM.UseVisualStyleBackColor = true;
+            this.chkHBM.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
             // 
-            // fightingRandom
+            // randomLabel
             // 
-            this.fightingRandom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.randomLabel.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.randomLabel.Location = new System.Drawing.Point(53, 16);
+            this.randomLabel.Name = "randomLabel";
+            this.randomLabel.Size = new System.Drawing.Size(211, 29);
+            this.randomLabel.TabIndex = 4;
+            this.randomLabel.Text = "Games that will be included in the\r\nrandom game option:";
+            this.randomLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // randomNone
+            // 
+            this.randomNone.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.randomNone.Location = new System.Drawing.Point(221, 49);
+            this.randomNone.Name = "randomNone";
+            this.randomNone.Size = new System.Drawing.Size(90, 25);
+            this.randomNone.TabIndex = 1;
+            this.randomNone.Text = "Select None";
+            this.randomNone.UseVisualStyleBackColor = true;
+            this.randomNone.Click += new System.EventHandler(this.randomNone_Click);
+            // 
+            // randomAll
+            // 
+            this.randomAll.Location = new System.Drawing.Point(6, 49);
+            this.randomAll.Name = "randomAll";
+            this.randomAll.Size = new System.Drawing.Size(90, 25);
+            this.randomAll.TabIndex = 0;
+            this.randomAll.Text = "Select All";
+            this.randomAll.UseVisualStyleBackColor = true;
+            this.randomAll.Click += new System.EventHandler(this.randomAll_Click);
+            // 
+            // tasofroRandom
+            // 
+            this.tasofroRandom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.fightingRandom.Controls.Add(this.fightingRandomPanel);
-            this.fightingRandom.Location = new System.Drawing.Point(6, 219);
-            this.fightingRandom.Name = "fightingRandom";
-            this.fightingRandom.Size = new System.Drawing.Size(295, 68);
-            this.fightingRandom.TabIndex = 3;
-            this.fightingRandom.TabStop = false;
-            this.fightingRandom.Text = "Fighting Games";
+            this.tasofroRandom.Controls.Add(this.tasofroRandomPanel);
+            this.tasofroRandom.Location = new System.Drawing.Point(6, 298);
+            this.tasofroRandom.Name = "tasofroRandom";
+            this.tasofroRandom.Size = new System.Drawing.Size(305, 66);
+            this.tasofroRandom.TabIndex = 5;
+            this.tasofroRandom.TabStop = false;
+            this.tasofroRandom.Text = "Twilight Frontier Games";
             // 
-            // fightingRandomPanel
+            // tasofroRandomPanel
             // 
-            this.fightingRandomPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.tasofroRandomPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.fightingRandomPanel.AutoScroll = true;
-            this.fightingRandomPanel.Controls.Add(this.chkIaMP);
-            this.fightingRandomPanel.Controls.Add(this.chkSWR);
-            this.fightingRandomPanel.Controls.Add(this.chkUoNL);
-            this.fightingRandomPanel.Controls.Add(this.chkHM);
-            this.fightingRandomPanel.Controls.Add(this.chkULiL);
-            this.fightingRandomPanel.Controls.Add(this.chkAoCF);
-            this.fightingRandomPanel.Location = new System.Drawing.Point(3, 16);
-            this.fightingRandomPanel.Margin = new System.Windows.Forms.Padding(0);
-            this.fightingRandomPanel.Name = "fightingRandomPanel";
-            this.fightingRandomPanel.Size = new System.Drawing.Size(289, 49);
-            this.fightingRandomPanel.TabIndex = 1;
+            this.tasofroRandomPanel.AutoScroll = true;
+            this.tasofroRandomPanel.Controls.Add(this.chkIaMP);
+            this.tasofroRandomPanel.Controls.Add(this.chkSWR);
+            this.tasofroRandomPanel.Controls.Add(this.chkUoNL);
+            this.tasofroRandomPanel.Controls.Add(this.chkHM);
+            this.tasofroRandomPanel.Controls.Add(this.chkULiL);
+            this.tasofroRandomPanel.Controls.Add(this.chkAoCF);
+            this.tasofroRandomPanel.Controls.Add(this.chkGI);
+            this.tasofroRandomPanel.Location = new System.Drawing.Point(3, 16);
+            this.tasofroRandomPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.tasofroRandomPanel.Name = "tasofroRandomPanel";
+            this.tasofroRandomPanel.Size = new System.Drawing.Size(299, 47);
+            this.tasofroRandomPanel.TabIndex = 1;
             // 
             // chkIaMP
             // 
@@ -909,15 +919,28 @@
             this.chkAoCF.UseVisualStyleBackColor = true;
             this.chkAoCF.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
             // 
+            // chkGI
+            // 
+            this.chkGI.AutoSize = true;
+            this.chkGI.Checked = true;
+            this.chkGI.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkGI.Location = new System.Drawing.Point(115, 26);
+            this.chkGI.Name = "chkGI";
+            this.chkGI.Size = new System.Drawing.Size(37, 17);
+            this.chkGI.TabIndex = 6;
+            this.chkGI.Text = "GI";
+            this.chkGI.UseVisualStyleBackColor = true;
+            this.chkGI.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
             // mainRandom
             // 
             this.mainRandom.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.mainRandom.Controls.Add(this.mainRandomPanel);
-            this.mainRandom.Location = new System.Drawing.Point(6, 80);
+            this.mainRandom.Location = new System.Drawing.Point(6, 128);
             this.mainRandom.Name = "mainRandom";
-            this.mainRandom.Size = new System.Drawing.Size(295, 133);
-            this.mainRandom.TabIndex = 2;
+            this.mainRandom.Size = new System.Drawing.Size(305, 90);
+            this.mainRandom.TabIndex = 3;
             this.mainRandom.TabStop = false;
             this.mainRandom.Text = "Main Games";
             // 
@@ -927,11 +950,6 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.mainRandomPanel.AutoScroll = true;
-            this.mainRandomPanel.Controls.Add(this.chkHRtP);
-            this.mainRandomPanel.Controls.Add(this.chkSoEW);
-            this.mainRandomPanel.Controls.Add(this.chkPoDD);
-            this.mainRandomPanel.Controls.Add(this.chkLLS);
-            this.mainRandomPanel.Controls.Add(this.chkMS);
             this.mainRandomPanel.Controls.Add(this.chkEoSD);
             this.mainRandomPanel.Controls.Add(this.chkPCB);
             this.mainRandomPanel.Controls.Add(this.chkIN);
@@ -948,8 +966,206 @@
             this.mainRandomPanel.Location = new System.Drawing.Point(3, 16);
             this.mainRandomPanel.Margin = new System.Windows.Forms.Padding(0);
             this.mainRandomPanel.Name = "mainRandomPanel";
-            this.mainRandomPanel.Size = new System.Drawing.Size(289, 114);
-            this.mainRandomPanel.TabIndex = 0;
+            this.mainRandomPanel.Size = new System.Drawing.Size(299, 71);
+            this.mainRandomPanel.TabIndex = 1;
+            // 
+            // chkEoSD
+            // 
+            this.chkEoSD.AutoSize = true;
+            this.chkEoSD.Checked = true;
+            this.chkEoSD.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkEoSD.Location = new System.Drawing.Point(3, 3);
+            this.chkEoSD.Name = "chkEoSD";
+            this.chkEoSD.Size = new System.Drawing.Size(54, 17);
+            this.chkEoSD.TabIndex = 0;
+            this.chkEoSD.Text = "EoSD";
+            this.chkEoSD.UseVisualStyleBackColor = true;
+            this.chkEoSD.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkPCB
+            // 
+            this.chkPCB.AutoSize = true;
+            this.chkPCB.Checked = true;
+            this.chkPCB.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkPCB.Location = new System.Drawing.Point(63, 3);
+            this.chkPCB.Name = "chkPCB";
+            this.chkPCB.Size = new System.Drawing.Size(47, 17);
+            this.chkPCB.TabIndex = 1;
+            this.chkPCB.Text = "PCB";
+            this.chkPCB.UseVisualStyleBackColor = true;
+            this.chkPCB.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkIN
+            // 
+            this.chkIN.AutoSize = true;
+            this.chkIN.Checked = true;
+            this.chkIN.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkIN.Location = new System.Drawing.Point(116, 3);
+            this.chkIN.Name = "chkIN";
+            this.chkIN.Size = new System.Drawing.Size(37, 17);
+            this.chkIN.TabIndex = 2;
+            this.chkIN.Text = "IN";
+            this.chkIN.UseVisualStyleBackColor = true;
+            this.chkIN.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkPoFV
+            // 
+            this.chkPoFV.AutoSize = true;
+            this.chkPoFV.Checked = true;
+            this.chkPoFV.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkPoFV.Location = new System.Drawing.Point(159, 3);
+            this.chkPoFV.Name = "chkPoFV";
+            this.chkPoFV.Size = new System.Drawing.Size(52, 17);
+            this.chkPoFV.TabIndex = 3;
+            this.chkPoFV.Text = "PoFV";
+            this.chkPoFV.UseVisualStyleBackColor = true;
+            this.chkPoFV.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkMoF
+            // 
+            this.chkMoF.AutoSize = true;
+            this.chkMoF.Checked = true;
+            this.chkMoF.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkMoF.Location = new System.Drawing.Point(217, 3);
+            this.chkMoF.Name = "chkMoF";
+            this.chkMoF.Size = new System.Drawing.Size(47, 17);
+            this.chkMoF.TabIndex = 4;
+            this.chkMoF.Text = "MoF";
+            this.chkMoF.UseVisualStyleBackColor = true;
+            this.chkMoF.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkSA
+            // 
+            this.chkSA.AutoSize = true;
+            this.chkSA.Checked = true;
+            this.chkSA.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkSA.Location = new System.Drawing.Point(3, 26);
+            this.chkSA.Name = "chkSA";
+            this.chkSA.Size = new System.Drawing.Size(40, 17);
+            this.chkSA.TabIndex = 5;
+            this.chkSA.Text = "SA";
+            this.chkSA.UseVisualStyleBackColor = true;
+            this.chkSA.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkUFO
+            // 
+            this.chkUFO.AutoSize = true;
+            this.chkUFO.Checked = true;
+            this.chkUFO.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkUFO.Location = new System.Drawing.Point(49, 26);
+            this.chkUFO.Name = "chkUFO";
+            this.chkUFO.Size = new System.Drawing.Size(48, 17);
+            this.chkUFO.TabIndex = 6;
+            this.chkUFO.Text = "UFO";
+            this.chkUFO.UseVisualStyleBackColor = true;
+            this.chkUFO.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkTD
+            // 
+            this.chkTD.AutoSize = true;
+            this.chkTD.Checked = true;
+            this.chkTD.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkTD.Location = new System.Drawing.Point(103, 26);
+            this.chkTD.Name = "chkTD";
+            this.chkTD.Size = new System.Drawing.Size(41, 17);
+            this.chkTD.TabIndex = 7;
+            this.chkTD.Text = "TD";
+            this.chkTD.UseVisualStyleBackColor = true;
+            this.chkTD.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkDDC
+            // 
+            this.chkDDC.AutoSize = true;
+            this.chkDDC.Checked = true;
+            this.chkDDC.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkDDC.Location = new System.Drawing.Point(150, 26);
+            this.chkDDC.Name = "chkDDC";
+            this.chkDDC.Size = new System.Drawing.Size(49, 17);
+            this.chkDDC.TabIndex = 8;
+            this.chkDDC.Text = "DDC";
+            this.chkDDC.UseVisualStyleBackColor = true;
+            this.chkDDC.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkLoLK
+            // 
+            this.chkLoLK.AutoSize = true;
+            this.chkLoLK.Checked = true;
+            this.chkLoLK.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkLoLK.Location = new System.Drawing.Point(205, 26);
+            this.chkLoLK.Name = "chkLoLK";
+            this.chkLoLK.Size = new System.Drawing.Size(51, 17);
+            this.chkLoLK.TabIndex = 9;
+            this.chkLoLK.Text = "LoLK";
+            this.chkLoLK.UseVisualStyleBackColor = true;
+            this.chkLoLK.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkHSiFS
+            // 
+            this.chkHSiFS.AutoSize = true;
+            this.chkHSiFS.Checked = true;
+            this.chkHSiFS.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkHSiFS.Location = new System.Drawing.Point(3, 49);
+            this.chkHSiFS.Name = "chkHSiFS";
+            this.chkHSiFS.Size = new System.Drawing.Size(56, 17);
+            this.chkHSiFS.TabIndex = 10;
+            this.chkHSiFS.Text = "HSiFS";
+            this.chkHSiFS.UseVisualStyleBackColor = true;
+            this.chkHSiFS.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkWBaWC
+            // 
+            this.chkWBaWC.AutoSize = true;
+            this.chkWBaWC.Checked = true;
+            this.chkWBaWC.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkWBaWC.Location = new System.Drawing.Point(65, 49);
+            this.chkWBaWC.Name = "chkWBaWC";
+            this.chkWBaWC.Size = new System.Drawing.Size(68, 17);
+            this.chkWBaWC.TabIndex = 11;
+            this.chkWBaWC.Text = "WBaWC";
+            this.chkWBaWC.UseVisualStyleBackColor = true;
+            this.chkWBaWC.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // chkUM
+            // 
+            this.chkUM.AutoSize = true;
+            this.chkUM.Checked = true;
+            this.chkUM.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkUM.Location = new System.Drawing.Point(139, 49);
+            this.chkUM.Name = "chkUM";
+            this.chkUM.Size = new System.Drawing.Size(43, 17);
+            this.chkUM.TabIndex = 12;
+            this.chkUM.Text = "UM";
+            this.chkUM.UseVisualStyleBackColor = true;
+            this.chkUM.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
+            // 
+            // pc98Random
+            // 
+            this.pc98Random.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pc98Random.Controls.Add(this.pc98RandomPanel);
+            this.pc98Random.Location = new System.Drawing.Point(6, 80);
+            this.pc98Random.Name = "pc98Random";
+            this.pc98Random.Size = new System.Drawing.Size(305, 42);
+            this.pc98Random.TabIndex = 2;
+            this.pc98Random.TabStop = false;
+            this.pc98Random.Text = "PC-98 Games";
+            // 
+            // pc98RandomPanel
+            // 
+            this.pc98RandomPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pc98RandomPanel.AutoScroll = true;
+            this.pc98RandomPanel.Controls.Add(this.chkHRtP);
+            this.pc98RandomPanel.Controls.Add(this.chkSoEW);
+            this.pc98RandomPanel.Controls.Add(this.chkPoDD);
+            this.pc98RandomPanel.Controls.Add(this.chkLLS);
+            this.pc98RandomPanel.Controls.Add(this.chkMS);
+            this.pc98RandomPanel.Location = new System.Drawing.Point(3, 16);
+            this.pc98RandomPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.pc98RandomPanel.Name = "pc98RandomPanel";
+            this.pc98RandomPanel.Size = new System.Drawing.Size(299, 23);
+            this.pc98RandomPanel.TabIndex = 0;
             // 
             // chkHRtP
             // 
@@ -1015,175 +1231,6 @@
             this.chkMS.Text = "MS";
             this.chkMS.UseVisualStyleBackColor = true;
             this.chkMS.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkEoSD
-            // 
-            this.chkEoSD.AutoSize = true;
-            this.chkEoSD.Checked = true;
-            this.chkEoSD.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkEoSD.Location = new System.Drawing.Point(3, 26);
-            this.chkEoSD.Name = "chkEoSD";
-            this.chkEoSD.Size = new System.Drawing.Size(54, 17);
-            this.chkEoSD.TabIndex = 5;
-            this.chkEoSD.Text = "EoSD";
-            this.chkEoSD.UseVisualStyleBackColor = true;
-            this.chkEoSD.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkPCB
-            // 
-            this.chkPCB.AutoSize = true;
-            this.chkPCB.Checked = true;
-            this.chkPCB.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkPCB.Location = new System.Drawing.Point(63, 26);
-            this.chkPCB.Name = "chkPCB";
-            this.chkPCB.Size = new System.Drawing.Size(47, 17);
-            this.chkPCB.TabIndex = 6;
-            this.chkPCB.Text = "PCB";
-            this.chkPCB.UseVisualStyleBackColor = true;
-            this.chkPCB.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkIN
-            // 
-            this.chkIN.AutoSize = true;
-            this.chkIN.Checked = true;
-            this.chkIN.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkIN.Location = new System.Drawing.Point(116, 26);
-            this.chkIN.Name = "chkIN";
-            this.chkIN.Size = new System.Drawing.Size(37, 17);
-            this.chkIN.TabIndex = 7;
-            this.chkIN.Text = "IN";
-            this.chkIN.UseVisualStyleBackColor = true;
-            this.chkIN.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkPoFV
-            // 
-            this.chkPoFV.AutoSize = true;
-            this.chkPoFV.Checked = true;
-            this.chkPoFV.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkPoFV.Location = new System.Drawing.Point(159, 26);
-            this.chkPoFV.Name = "chkPoFV";
-            this.chkPoFV.Size = new System.Drawing.Size(52, 17);
-            this.chkPoFV.TabIndex = 8;
-            this.chkPoFV.Text = "PoFV";
-            this.chkPoFV.UseVisualStyleBackColor = true;
-            this.chkPoFV.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkMoF
-            // 
-            this.chkMoF.AutoSize = true;
-            this.chkMoF.Checked = true;
-            this.chkMoF.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkMoF.Location = new System.Drawing.Point(217, 26);
-            this.chkMoF.Name = "chkMoF";
-            this.chkMoF.Size = new System.Drawing.Size(47, 17);
-            this.chkMoF.TabIndex = 9;
-            this.chkMoF.Text = "MoF";
-            this.chkMoF.UseVisualStyleBackColor = true;
-            this.chkMoF.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkSA
-            // 
-            this.chkSA.AutoSize = true;
-            this.chkSA.Checked = true;
-            this.chkSA.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkSA.Location = new System.Drawing.Point(3, 49);
-            this.chkSA.Name = "chkSA";
-            this.chkSA.Size = new System.Drawing.Size(40, 17);
-            this.chkSA.TabIndex = 10;
-            this.chkSA.Text = "SA";
-            this.chkSA.UseVisualStyleBackColor = true;
-            this.chkSA.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkUFO
-            // 
-            this.chkUFO.AutoSize = true;
-            this.chkUFO.Checked = true;
-            this.chkUFO.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkUFO.Location = new System.Drawing.Point(49, 49);
-            this.chkUFO.Name = "chkUFO";
-            this.chkUFO.Size = new System.Drawing.Size(48, 17);
-            this.chkUFO.TabIndex = 11;
-            this.chkUFO.Text = "UFO";
-            this.chkUFO.UseVisualStyleBackColor = true;
-            this.chkUFO.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkTD
-            // 
-            this.chkTD.AutoSize = true;
-            this.chkTD.Checked = true;
-            this.chkTD.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkTD.Location = new System.Drawing.Point(103, 49);
-            this.chkTD.Name = "chkTD";
-            this.chkTD.Size = new System.Drawing.Size(41, 17);
-            this.chkTD.TabIndex = 12;
-            this.chkTD.Text = "TD";
-            this.chkTD.UseVisualStyleBackColor = true;
-            this.chkTD.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkDDC
-            // 
-            this.chkDDC.AutoSize = true;
-            this.chkDDC.Checked = true;
-            this.chkDDC.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkDDC.Location = new System.Drawing.Point(150, 49);
-            this.chkDDC.Name = "chkDDC";
-            this.chkDDC.Size = new System.Drawing.Size(49, 17);
-            this.chkDDC.TabIndex = 13;
-            this.chkDDC.Text = "DDC";
-            this.chkDDC.UseVisualStyleBackColor = true;
-            this.chkDDC.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkLoLK
-            // 
-            this.chkLoLK.AutoSize = true;
-            this.chkLoLK.Checked = true;
-            this.chkLoLK.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkLoLK.Location = new System.Drawing.Point(205, 49);
-            this.chkLoLK.Name = "chkLoLK";
-            this.chkLoLK.Size = new System.Drawing.Size(51, 17);
-            this.chkLoLK.TabIndex = 14;
-            this.chkLoLK.Text = "LoLK";
-            this.chkLoLK.UseVisualStyleBackColor = true;
-            this.chkLoLK.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkHSiFS
-            // 
-            this.chkHSiFS.AutoSize = true;
-            this.chkHSiFS.Checked = true;
-            this.chkHSiFS.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkHSiFS.Location = new System.Drawing.Point(3, 72);
-            this.chkHSiFS.Name = "chkHSiFS";
-            this.chkHSiFS.Size = new System.Drawing.Size(56, 17);
-            this.chkHSiFS.TabIndex = 15;
-            this.chkHSiFS.Text = "HSiFS";
-            this.chkHSiFS.UseVisualStyleBackColor = true;
-            this.chkHSiFS.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkWBaWC
-            // 
-            this.chkWBaWC.AutoSize = true;
-            this.chkWBaWC.Checked = true;
-            this.chkWBaWC.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkWBaWC.Location = new System.Drawing.Point(65, 72);
-            this.chkWBaWC.Name = "chkWBaWC";
-            this.chkWBaWC.Size = new System.Drawing.Size(68, 17);
-            this.chkWBaWC.TabIndex = 16;
-            this.chkWBaWC.Text = "WBaWC";
-            this.chkWBaWC.UseVisualStyleBackColor = true;
-            this.chkWBaWC.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
-            // chkUM
-            // 
-            this.chkUM.AutoSize = true;
-            this.chkUM.Checked = true;
-            this.chkUM.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkUM.Location = new System.Drawing.Point(139, 72);
-            this.chkUM.Name = "chkUM";
-            this.chkUM.Size = new System.Drawing.Size(43, 17);
-            this.chkUM.TabIndex = 17;
-            this.chkUM.Text = "UM";
-            this.chkUM.UseVisualStyleBackColor = true;
-            this.chkUM.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
             // 
             // launcherSettings
             // 
@@ -1359,7 +1406,7 @@
             this.replays.Location = new System.Drawing.Point(4, 22);
             this.replays.Name = "replays";
             this.replays.Padding = new System.Windows.Forms.Padding(3);
-            this.replays.Size = new System.Drawing.Size(527, 585);
+            this.replays.Size = new System.Drawing.Size(537, 555);
             this.replays.TabIndex = 3;
             this.replays.Text = "Replays";
             // 
@@ -1371,7 +1418,7 @@
             this.replayBrowser.Location = new System.Drawing.Point(0, 29);
             this.replayBrowser.MinimumSize = new System.Drawing.Size(20, 20);
             this.replayBrowser.Name = "replayBrowser";
-            this.replayBrowser.Size = new System.Drawing.Size(524, 556);
+            this.replayBrowser.Size = new System.Drawing.Size(534, 449);
             this.replayBrowser.TabIndex = 2;
             this.replayBrowser.Url = new System.Uri("", System.UriKind.Relative);
             this.replayBrowser.Navigating += new System.Windows.Forms.WebBrowserNavigatingEventHandler(this.replayBrowser_Navigating);
@@ -1386,7 +1433,7 @@
             this.replayPanel.Controls.Add(this.maribelReplays);
             this.replayPanel.Location = new System.Drawing.Point(0, 0);
             this.replayPanel.Name = "replayPanel";
-            this.replayPanel.Size = new System.Drawing.Size(518, 29);
+            this.replayPanel.Size = new System.Drawing.Size(528, 29);
             this.replayPanel.TabIndex = 1;
             // 
             // linkReplays
@@ -1436,7 +1483,7 @@
             this.customGames.Location = new System.Drawing.Point(4, 22);
             this.customGames.Name = "customGames";
             this.customGames.Padding = new System.Windows.Forms.Padding(3);
-            this.customGames.Size = new System.Drawing.Size(527, 585);
+            this.customGames.Size = new System.Drawing.Size(537, 555);
             this.customGames.TabIndex = 1;
             this.customGames.Text = "Custom Games";
             // 
@@ -1462,7 +1509,7 @@
             this.customList.LargeImageList = this.customImages;
             this.customList.Location = new System.Drawing.Point(272, 3);
             this.customList.Name = "customList";
-            this.customList.Size = new System.Drawing.Size(246, 579);
+            this.customList.Size = new System.Drawing.Size(256, 472);
             this.customList.SmallImageList = this.customImages;
             this.customList.TabIndex = 3;
             this.customList.UseCompatibleStateImageBehavior = false;
@@ -1476,7 +1523,7 @@
             // 
             this.customLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.customLabel.AutoSize = true;
-            this.customLabel.Location = new System.Drawing.Point(3, 687);
+            this.customLabel.Location = new System.Drawing.Point(3, 580);
             this.customLabel.Name = "customLabel";
             this.customLabel.Size = new System.Drawing.Size(0, 13);
             this.customLabel.TabIndex = 2;
@@ -1490,7 +1537,7 @@
             this.customTree.LabelEdit = true;
             this.customTree.Location = new System.Drawing.Point(3, 3);
             this.customTree.Name = "customTree";
-            this.customTree.Size = new System.Drawing.Size(167, 579);
+            this.customTree.Size = new System.Drawing.Size(167, 472);
             this.customTree.TabIndex = 1;
             this.customTree.AfterLabelEdit += new System.Windows.Forms.NodeLabelEditEventHandler(this.customTree_AfterLabelEdit);
             this.customTree.NodeMouseClick += new System.Windows.Forms.TreeNodeMouseClickEventHandler(this.customTree_NodeMouseClick);
@@ -1509,54 +1556,53 @@
             this.mainControl.Margin = new System.Windows.Forms.Padding(1);
             this.mainControl.Name = "mainControl";
             this.mainControl.SelectedIndex = 0;
-            this.mainControl.Size = new System.Drawing.Size(535, 611);
+            this.mainControl.Size = new System.Drawing.Size(545, 581);
             this.mainControl.TabIndex = 0;
             this.mainControl.Deselected += new System.Windows.Forms.TabControlEventHandler(this.mainControl_Deselected);
             // 
             // games
             // 
             this.games.BackColor = System.Drawing.Color.Transparent;
+            this.games.Controls.Add(this.spinoffGroup);
             this.games.Controls.Add(this.btnRandom);
-            this.games.Controls.Add(this.otherGroup);
-            this.games.Controls.Add(this.fightingGroup);
+            this.games.Controls.Add(this.tasofroGroup);
             this.games.Controls.Add(this.mainGroup);
+            this.games.Controls.Add(this.pc98Group);
             this.games.Location = new System.Drawing.Point(4, 22);
             this.games.Name = "games";
             this.games.Padding = new System.Windows.Forms.Padding(3);
-            this.games.Size = new System.Drawing.Size(527, 585);
+            this.games.Size = new System.Drawing.Size(537, 555);
             this.games.TabIndex = 6;
             this.games.Text = "Games";
             // 
-            // otherGroup
+            // spinoffGroup
             // 
-            this.otherGroup.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.otherGroup.Controls.Add(this.miscLayoutPanel);
-            this.otherGroup.Location = new System.Drawing.Point(6, 413);
-            this.otherGroup.Name = "otherGroup";
-            this.otherGroup.Size = new System.Drawing.Size(512, 123);
-            this.otherGroup.TabIndex = 3;
-            this.otherGroup.TabStop = false;
-            this.otherGroup.Text = "Other Games";
+            this.spinoffGroup.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.spinoffGroup.Controls.Add(this.spinoffLayoutPanel);
+            this.spinoffGroup.Location = new System.Drawing.Point(6, 285);
+            this.spinoffGroup.Name = "spinoffGroup";
+            this.spinoffGroup.Size = new System.Drawing.Size(259, 223);
+            this.spinoffGroup.TabIndex = 3;
+            this.spinoffGroup.TabStop = false;
+            this.spinoffGroup.Text = "Spinoffs";
             // 
-            // miscLayoutPanel
+            // spinoffLayoutPanel
             // 
-            this.miscLayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.spinoffLayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.miscLayoutPanel.AutoScroll = true;
-            this.miscLayoutPanel.Controls.Add(this.btnStB);
-            this.miscLayoutPanel.Controls.Add(this.btnDS);
-            this.miscLayoutPanel.Controls.Add(this.btnGFW);
-            this.miscLayoutPanel.Controls.Add(this.btnISC);
-            this.miscLayoutPanel.Controls.Add(this.btnVD);
-            this.miscLayoutPanel.Controls.Add(this.btnGI);
-            this.miscLayoutPanel.Controls.Add(this.btnHBM);
-            this.miscLayoutPanel.Location = new System.Drawing.Point(3, 16);
-            this.miscLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
-            this.miscLayoutPanel.Name = "miscLayoutPanel";
-            this.miscLayoutPanel.Size = new System.Drawing.Size(506, 104);
-            this.miscLayoutPanel.TabIndex = 2;
+            this.spinoffLayoutPanel.AutoScroll = true;
+            this.spinoffLayoutPanel.Controls.Add(this.btnStB);
+            this.spinoffLayoutPanel.Controls.Add(this.btnDS);
+            this.spinoffLayoutPanel.Controls.Add(this.btnGFW);
+            this.spinoffLayoutPanel.Controls.Add(this.btnISC);
+            this.spinoffLayoutPanel.Controls.Add(this.btnVD);
+            this.spinoffLayoutPanel.Controls.Add(this.btnHBM);
+            this.spinoffLayoutPanel.Location = new System.Drawing.Point(3, 16);
+            this.spinoffLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.spinoffLayoutPanel.Name = "spinoffLayoutPanel";
+            this.spinoffLayoutPanel.Size = new System.Drawing.Size(253, 204);
+            this.spinoffLayoutPanel.TabIndex = 2;
             // 
             // btnStB
             // 
@@ -1601,7 +1647,7 @@
             this.btnGFW.ContextMenuStrip = this.gameContextMenu;
             this.btnGFW.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnGFW.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.btnGFW.Location = new System.Drawing.Point(255, 3);
+            this.btnGFW.Location = new System.Drawing.Point(3, 53);
             this.btnGFW.Name = "btnGFW";
             this.btnGFW.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnGFW.Size = new System.Drawing.Size(120, 44);
@@ -1619,7 +1665,7 @@
             this.btnISC.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnISC.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnISC.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnISC.Location = new System.Drawing.Point(381, 3);
+            this.btnISC.Location = new System.Drawing.Point(129, 53);
             this.btnISC.Name = "btnISC";
             this.btnISC.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnISC.Size = new System.Drawing.Size(120, 44);
@@ -1637,7 +1683,7 @@
             this.btnVD.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnVD.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnVD.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnVD.Location = new System.Drawing.Point(3, 53);
+            this.btnVD.Location = new System.Drawing.Point(3, 103);
             this.btnVD.Name = "btnVD";
             this.btnVD.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnVD.Size = new System.Drawing.Size(120, 44);
@@ -1647,53 +1693,54 @@
             this.btnVD.UseVisualStyleBackColor = true;
             this.btnVD.Click += new System.EventHandler(this.btn_Click);
             // 
-            // btnGI
+            // btnHBM
             // 
-            this.btnGI.BackgroundImage = global::Touhou_Launcher.Properties.Resources.gig;
-            this.btnGI.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.btnGI.ContextMenuStrip = this.gameContextMenu;
-            this.btnGI.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.btnGI.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.btnGI.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnGI.Location = new System.Drawing.Point(129, 53);
-            this.btnGI.Name = "btnGI";
-            this.btnGI.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
-            this.btnGI.Size = new System.Drawing.Size(120, 44);
-            this.btnGI.TabIndex = 5;
-            this.btnGI.Text = "Gouyoku Ibun";
-            this.btnGI.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnGI.UseVisualStyleBackColor = true;
-            this.btnGI.Click += new System.EventHandler(this.btn_Click);
+            this.btnHBM.BackgroundImage = global::Touhou_Launcher.Properties.Resources.hbmg;
+            this.btnHBM.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btnHBM.ContextMenuStrip = this.gameContextMenu;
+            this.btnHBM.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btnHBM.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.btnHBM.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.btnHBM.Location = new System.Drawing.Point(129, 103);
+            this.btnHBM.Name = "btnHBM";
+            this.btnHBM.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
+            this.btnHBM.Size = new System.Drawing.Size(120, 44);
+            this.btnHBM.TabIndex = 5;
+            this.btnHBM.Text = "100th Black Market";
+            this.btnHBM.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btnHBM.UseVisualStyleBackColor = true;
+            this.btnHBM.Click += new System.EventHandler(this.btn_Click);
             // 
-            // fightingGroup
+            // tasofroGroup
             // 
-            this.fightingGroup.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            this.tasofroGroup.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.fightingGroup.Controls.Add(this.fightingLayoutPanel);
-            this.fightingGroup.Location = new System.Drawing.Point(6, 284);
-            this.fightingGroup.Name = "fightingGroup";
-            this.fightingGroup.Size = new System.Drawing.Size(512, 123);
-            this.fightingGroup.TabIndex = 2;
-            this.fightingGroup.TabStop = false;
-            this.fightingGroup.Text = "Fighting Games";
+            this.tasofroGroup.Controls.Add(this.tasofroLayoutPanel);
+            this.tasofroGroup.Location = new System.Drawing.Point(271, 285);
+            this.tasofroGroup.Name = "tasofroGroup";
+            this.tasofroGroup.Size = new System.Drawing.Size(259, 223);
+            this.tasofroGroup.TabIndex = 4;
+            this.tasofroGroup.TabStop = false;
+            this.tasofroGroup.Text = "Twilight Frontier Games";
             // 
-            // fightingLayoutPanel
+            // tasofroLayoutPanel
             // 
-            this.fightingLayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.tasofroLayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.fightingLayoutPanel.AutoScroll = true;
-            this.fightingLayoutPanel.Controls.Add(this.btnIaMP);
-            this.fightingLayoutPanel.Controls.Add(this.btnSWR);
-            this.fightingLayoutPanel.Controls.Add(this.btnUoNL);
-            this.fightingLayoutPanel.Controls.Add(this.btnHM);
-            this.fightingLayoutPanel.Controls.Add(this.btnULiL);
-            this.fightingLayoutPanel.Controls.Add(this.btnAoCF);
-            this.fightingLayoutPanel.Location = new System.Drawing.Point(3, 16);
-            this.fightingLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
-            this.fightingLayoutPanel.Name = "fightingLayoutPanel";
-            this.fightingLayoutPanel.Size = new System.Drawing.Size(506, 104);
-            this.fightingLayoutPanel.TabIndex = 2;
+            this.tasofroLayoutPanel.AutoScroll = true;
+            this.tasofroLayoutPanel.Controls.Add(this.btnIaMP);
+            this.tasofroLayoutPanel.Controls.Add(this.btnSWR);
+            this.tasofroLayoutPanel.Controls.Add(this.btnUoNL);
+            this.tasofroLayoutPanel.Controls.Add(this.btnHM);
+            this.tasofroLayoutPanel.Controls.Add(this.btnULiL);
+            this.tasofroLayoutPanel.Controls.Add(this.btnAoCF);
+            this.tasofroLayoutPanel.Controls.Add(this.btnGI);
+            this.tasofroLayoutPanel.Location = new System.Drawing.Point(3, 16);
+            this.tasofroLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.tasofroLayoutPanel.Name = "tasofroLayoutPanel";
+            this.tasofroLayoutPanel.Size = new System.Drawing.Size(253, 204);
+            this.tasofroLayoutPanel.TabIndex = 2;
             // 
             // btnIaMP
             // 
@@ -1739,7 +1786,7 @@
             this.btnUoNL.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnUoNL.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnUoNL.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnUoNL.Location = new System.Drawing.Point(255, 3);
+            this.btnUoNL.Location = new System.Drawing.Point(3, 53);
             this.btnUoNL.Name = "btnUoNL";
             this.btnUoNL.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnUoNL.Size = new System.Drawing.Size(120, 44);
@@ -1757,7 +1804,7 @@
             this.btnHM.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnHM.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnHM.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnHM.Location = new System.Drawing.Point(381, 3);
+            this.btnHM.Location = new System.Drawing.Point(129, 53);
             this.btnHM.Name = "btnHM";
             this.btnHM.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnHM.Size = new System.Drawing.Size(120, 44);
@@ -1775,7 +1822,7 @@
             this.btnULiL.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnULiL.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnULiL.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnULiL.Location = new System.Drawing.Point(3, 53);
+            this.btnULiL.Location = new System.Drawing.Point(3, 103);
             this.btnULiL.Name = "btnULiL";
             this.btnULiL.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnULiL.Size = new System.Drawing.Size(120, 44);
@@ -1793,7 +1840,7 @@
             this.btnAoCF.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnAoCF.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnAoCF.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnAoCF.Location = new System.Drawing.Point(129, 53);
+            this.btnAoCF.Location = new System.Drawing.Point(129, 103);
             this.btnAoCF.Name = "btnAoCF";
             this.btnAoCF.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnAoCF.Size = new System.Drawing.Size(120, 44);
@@ -1803,16 +1850,34 @@
             this.btnAoCF.UseVisualStyleBackColor = true;
             this.btnAoCF.Click += new System.EventHandler(this.btn_Click);
             // 
+            // btnGI
+            // 
+            this.btnGI.BackgroundImage = global::Touhou_Launcher.Properties.Resources.gig;
+            this.btnGI.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btnGI.ContextMenuStrip = this.gameContextMenu;
+            this.btnGI.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btnGI.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
+            this.btnGI.ForeColor = System.Drawing.SystemColors.Window;
+            this.btnGI.Location = new System.Drawing.Point(3, 153);
+            this.btnGI.Name = "btnGI";
+            this.btnGI.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
+            this.btnGI.Size = new System.Drawing.Size(120, 44);
+            this.btnGI.TabIndex = 6;
+            this.btnGI.Text = "Gouyoku Ibun";
+            this.btnGI.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btnGI.UseVisualStyleBackColor = true;
+            this.btnGI.Click += new System.EventHandler(this.btn_Click);
+            // 
             // mainGroup
             // 
             this.mainGroup.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.mainGroup.Controls.Add(this.mainLayoutPanel);
-            this.mainGroup.Location = new System.Drawing.Point(6, 6);
+            this.mainGroup.Location = new System.Drawing.Point(145, 6);
             this.mainGroup.Name = "mainGroup";
-            this.mainGroup.Size = new System.Drawing.Size(512, 272);
-            this.mainGroup.TabIndex = 1;
+            this.mainGroup.Size = new System.Drawing.Size(385, 273);
+            this.mainGroup.TabIndex = 2;
             this.mainGroup.TabStop = false;
             this.mainGroup.Text = "Main Games";
             // 
@@ -1822,11 +1887,6 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.mainLayoutPanel.AutoScroll = true;
-            this.mainLayoutPanel.Controls.Add(this.btnHRtP);
-            this.mainLayoutPanel.Controls.Add(this.btnSoEW);
-            this.mainLayoutPanel.Controls.Add(this.btnPoDD);
-            this.mainLayoutPanel.Controls.Add(this.btnLLS);
-            this.mainLayoutPanel.Controls.Add(this.btnMS);
             this.mainLayoutPanel.Controls.Add(this.btnEoSD);
             this.mainLayoutPanel.Controls.Add(this.btnPCB);
             this.mainLayoutPanel.Controls.Add(this.btnIN);
@@ -1843,7 +1903,7 @@
             this.mainLayoutPanel.Location = new System.Drawing.Point(3, 16);
             this.mainLayoutPanel.Margin = new System.Windows.Forms.Padding(0);
             this.mainLayoutPanel.Name = "mainLayoutPanel";
-            this.mainLayoutPanel.Size = new System.Drawing.Size(506, 253);
+            this.mainLayoutPanel.Size = new System.Drawing.Size(379, 254);
             this.mainLayoutPanel.TabIndex = 2;
             // 
             // btnEoSD
@@ -1854,11 +1914,11 @@
             this.btnEoSD.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnEoSD.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnEoSD.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnEoSD.Location = new System.Drawing.Point(129, 53);
+            this.btnEoSD.Location = new System.Drawing.Point(3, 3);
             this.btnEoSD.Name = "btnEoSD";
             this.btnEoSD.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnEoSD.Size = new System.Drawing.Size(120, 44);
-            this.btnEoSD.TabIndex = 5;
+            this.btnEoSD.TabIndex = 0;
             this.btnEoSD.Text = "Embodiment of Scarlet Devil";
             this.btnEoSD.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnEoSD.UseVisualStyleBackColor = true;
@@ -1872,11 +1932,11 @@
             this.btnPCB.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnPCB.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnPCB.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnPCB.Location = new System.Drawing.Point(255, 53);
+            this.btnPCB.Location = new System.Drawing.Point(129, 3);
             this.btnPCB.Name = "btnPCB";
             this.btnPCB.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnPCB.Size = new System.Drawing.Size(120, 44);
-            this.btnPCB.TabIndex = 6;
+            this.btnPCB.TabIndex = 1;
             this.btnPCB.Text = "Perfect Cherry Blossom";
             this.btnPCB.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnPCB.UseVisualStyleBackColor = true;
@@ -1890,11 +1950,11 @@
             this.btnIN.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnIN.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnIN.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnIN.Location = new System.Drawing.Point(381, 53);
+            this.btnIN.Location = new System.Drawing.Point(255, 3);
             this.btnIN.Name = "btnIN";
             this.btnIN.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnIN.Size = new System.Drawing.Size(120, 44);
-            this.btnIN.TabIndex = 7;
+            this.btnIN.TabIndex = 2;
             this.btnIN.Text = "Imperishable Night";
             this.btnIN.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnIN.UseVisualStyleBackColor = true;
@@ -1908,11 +1968,11 @@
             this.btnPoFV.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnPoFV.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnPoFV.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnPoFV.Location = new System.Drawing.Point(3, 103);
+            this.btnPoFV.Location = new System.Drawing.Point(3, 53);
             this.btnPoFV.Name = "btnPoFV";
             this.btnPoFV.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnPoFV.Size = new System.Drawing.Size(120, 44);
-            this.btnPoFV.TabIndex = 8;
+            this.btnPoFV.TabIndex = 3;
             this.btnPoFV.Text = "Phantasmagoria of Flower View";
             this.btnPoFV.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnPoFV.UseVisualStyleBackColor = true;
@@ -1926,11 +1986,11 @@
             this.btnMoF.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnMoF.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnMoF.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnMoF.Location = new System.Drawing.Point(129, 103);
+            this.btnMoF.Location = new System.Drawing.Point(129, 53);
             this.btnMoF.Name = "btnMoF";
             this.btnMoF.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnMoF.Size = new System.Drawing.Size(120, 44);
-            this.btnMoF.TabIndex = 9;
+            this.btnMoF.TabIndex = 4;
             this.btnMoF.Text = "Mountain of Faith";
             this.btnMoF.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnMoF.UseVisualStyleBackColor = true;
@@ -1944,11 +2004,11 @@
             this.btnSA.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnSA.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnSA.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnSA.Location = new System.Drawing.Point(255, 103);
+            this.btnSA.Location = new System.Drawing.Point(255, 53);
             this.btnSA.Name = "btnSA";
             this.btnSA.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnSA.Size = new System.Drawing.Size(120, 44);
-            this.btnSA.TabIndex = 10;
+            this.btnSA.TabIndex = 5;
             this.btnSA.Text = "Subterranean Animism";
             this.btnSA.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnSA.UseVisualStyleBackColor = true;
@@ -1962,11 +2022,11 @@
             this.btnUFO.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnUFO.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnUFO.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnUFO.Location = new System.Drawing.Point(381, 103);
+            this.btnUFO.Location = new System.Drawing.Point(3, 103);
             this.btnUFO.Name = "btnUFO";
             this.btnUFO.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnUFO.Size = new System.Drawing.Size(120, 44);
-            this.btnUFO.TabIndex = 11;
+            this.btnUFO.TabIndex = 6;
             this.btnUFO.Text = "Undefined Fantastic Object";
             this.btnUFO.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnUFO.UseVisualStyleBackColor = true;
@@ -1980,11 +2040,11 @@
             this.btnTD.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnTD.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnTD.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnTD.Location = new System.Drawing.Point(3, 153);
+            this.btnTD.Location = new System.Drawing.Point(129, 103);
             this.btnTD.Name = "btnTD";
             this.btnTD.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnTD.Size = new System.Drawing.Size(120, 44);
-            this.btnTD.TabIndex = 12;
+            this.btnTD.TabIndex = 7;
             this.btnTD.Text = "Ten Desires";
             this.btnTD.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnTD.UseVisualStyleBackColor = true;
@@ -1998,11 +2058,11 @@
             this.btnDDC.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnDDC.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnDDC.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnDDC.Location = new System.Drawing.Point(129, 153);
+            this.btnDDC.Location = new System.Drawing.Point(255, 103);
             this.btnDDC.Name = "btnDDC";
             this.btnDDC.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnDDC.Size = new System.Drawing.Size(120, 44);
-            this.btnDDC.TabIndex = 13;
+            this.btnDDC.TabIndex = 8;
             this.btnDDC.Text = "Double Dealing Character";
             this.btnDDC.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnDDC.UseVisualStyleBackColor = true;
@@ -2016,11 +2076,11 @@
             this.btnLoLK.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnLoLK.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnLoLK.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnLoLK.Location = new System.Drawing.Point(255, 153);
+            this.btnLoLK.Location = new System.Drawing.Point(3, 153);
             this.btnLoLK.Name = "btnLoLK";
             this.btnLoLK.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnLoLK.Size = new System.Drawing.Size(120, 44);
-            this.btnLoLK.TabIndex = 14;
+            this.btnLoLK.TabIndex = 9;
             this.btnLoLK.Text = "Legacy of Lunatic Kingdom";
             this.btnLoLK.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnLoLK.UseVisualStyleBackColor = true;
@@ -2034,11 +2094,11 @@
             this.btnHSiFS.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnHSiFS.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnHSiFS.ForeColor = System.Drawing.SystemColors.Window;
-            this.btnHSiFS.Location = new System.Drawing.Point(381, 153);
+            this.btnHSiFS.Location = new System.Drawing.Point(129, 153);
             this.btnHSiFS.Name = "btnHSiFS";
             this.btnHSiFS.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnHSiFS.Size = new System.Drawing.Size(120, 44);
-            this.btnHSiFS.TabIndex = 15;
+            this.btnHSiFS.TabIndex = 10;
             this.btnHSiFS.Text = "Hidden Star in Four Seasons";
             this.btnHSiFS.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnHSiFS.UseVisualStyleBackColor = true;
@@ -2052,11 +2112,11 @@
             this.btnWBaWC.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnWBaWC.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnWBaWC.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnWBaWC.Location = new System.Drawing.Point(3, 203);
+            this.btnWBaWC.Location = new System.Drawing.Point(255, 153);
             this.btnWBaWC.Name = "btnWBaWC";
             this.btnWBaWC.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnWBaWC.Size = new System.Drawing.Size(120, 44);
-            this.btnWBaWC.TabIndex = 16;
+            this.btnWBaWC.TabIndex = 11;
             this.btnWBaWC.Text = "Wily Beast and Weakest Creature";
             this.btnWBaWC.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnWBaWC.UseVisualStyleBackColor = true;
@@ -2070,39 +2130,121 @@
             this.btnUM.Cursor = System.Windows.Forms.Cursors.Hand;
             this.btnUM.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
             this.btnUM.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnUM.Location = new System.Drawing.Point(129, 203);
+            this.btnUM.Location = new System.Drawing.Point(3, 203);
             this.btnUM.Name = "btnUM";
             this.btnUM.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
             this.btnUM.Size = new System.Drawing.Size(120, 44);
-            this.btnUM.TabIndex = 17;
+            this.btnUM.TabIndex = 12;
             this.btnUM.Text = "Unconnected Marketeers";
             this.btnUM.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnUM.UseVisualStyleBackColor = true;
             this.btnUM.Click += new System.EventHandler(this.btn_Click);
             // 
+            // pc98Group
+            // 
+            this.pc98Group.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.pc98Group.Controls.Add(this.pc98LayoutPanel);
+            this.pc98Group.Location = new System.Drawing.Point(6, 6);
+            this.pc98Group.Name = "pc98Group";
+            this.pc98Group.Size = new System.Drawing.Size(133, 273);
+            this.pc98Group.TabIndex = 1;
+            this.pc98Group.TabStop = false;
+            this.pc98Group.Text = "PC-98 Games";
+            // 
+            // pc98LayoutPanel
+            // 
+            this.pc98LayoutPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pc98LayoutPanel.AutoScroll = true;
+            this.pc98LayoutPanel.Controls.Add(this.btnHRtP);
+            this.pc98LayoutPanel.Controls.Add(this.btnSoEW);
+            this.pc98LayoutPanel.Controls.Add(this.btnPoDD);
+            this.pc98LayoutPanel.Controls.Add(this.btnLLS);
+            this.pc98LayoutPanel.Controls.Add(this.btnMS);
+            this.pc98LayoutPanel.Location = new System.Drawing.Point(3, 16);
+            this.pc98LayoutPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.pc98LayoutPanel.Name = "pc98LayoutPanel";
+            this.pc98LayoutPanel.Size = new System.Drawing.Size(127, 254);
+            this.pc98LayoutPanel.TabIndex = 2;
+            // 
             // trayMenu
             // 
             this.trayMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.trayPC98,
             this.trayMain,
-            this.trayFighting,
-            this.trayOther,
+            this.traySpinoff,
+            this.trayTasofro,
             this.trayCustom,
             this.trayRandom,
             this.toolStripSeparator2,
             this.trayOpen,
             this.trayExit});
             this.trayMenu.Name = "contextMenuStrip1";
-            this.trayMenu.Size = new System.Drawing.Size(158, 164);
+            this.trayMenu.Size = new System.Drawing.Size(201, 186);
             this.trayMenu.Opening += new System.ComponentModel.CancelEventHandler(this.trayMenu_Opening);
             // 
-            // trayMain
+            // trayPC98
             // 
-            this.trayMain.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.trayPC98.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.trayHRtP,
             this.traySoEW,
             this.trayPoDD,
             this.trayLLS,
-            this.trayMS,
+            this.trayMS});
+            this.trayPC98.Name = "trayPC98";
+            this.trayPC98.Size = new System.Drawing.Size(200, 22);
+            this.trayPC98.Text = "PC-98 Games";
+            // 
+            // trayHRtP
+            // 
+            this.trayHRtP.Image = global::Touhou_Launcher.Properties.Resources.Icon_th01;
+            this.trayHRtP.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayHRtP.Name = "trayHRtP";
+            this.trayHRtP.Size = new System.Drawing.Size(256, 38);
+            this.trayHRtP.Text = "Highly Responsive to Prayers";
+            this.trayHRtP.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // traySoEW
+            // 
+            this.traySoEW.Image = global::Touhou_Launcher.Properties.Resources.Icon_th02;
+            this.traySoEW.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.traySoEW.Name = "traySoEW";
+            this.traySoEW.Size = new System.Drawing.Size(256, 38);
+            this.traySoEW.Text = "Story of Eastern Wonderland";
+            this.traySoEW.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayPoDD
+            // 
+            this.trayPoDD.Image = global::Touhou_Launcher.Properties.Resources.Icon_th03;
+            this.trayPoDD.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayPoDD.Name = "trayPoDD";
+            this.trayPoDD.Size = new System.Drawing.Size(256, 38);
+            this.trayPoDD.Text = "Phantasmagoria of Dim. Dream";
+            this.trayPoDD.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayLLS
+            // 
+            this.trayLLS.Image = global::Touhou_Launcher.Properties.Resources.Icon_th04;
+            this.trayLLS.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayLLS.Name = "trayLLS";
+            this.trayLLS.Size = new System.Drawing.Size(256, 38);
+            this.trayLLS.Text = "Lotus Land Story";
+            this.trayLLS.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayMS
+            // 
+            this.trayMS.Image = global::Touhou_Launcher.Properties.Resources.Icon_th05;
+            this.trayMS.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayMS.Name = "trayMS";
+            this.trayMS.Size = new System.Drawing.Size(256, 38);
+            this.trayMS.Text = "Mystic Square";
+            this.trayMS.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayMain
+            // 
+            this.trayMain.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.trayEoSD,
             this.trayPCB,
             this.trayIN,
@@ -2117,53 +2259,8 @@
             this.trayWBaWC,
             this.trayUM});
             this.trayMain.Name = "trayMain";
-            this.trayMain.Size = new System.Drawing.Size(157, 22);
+            this.trayMain.Size = new System.Drawing.Size(200, 22);
             this.trayMain.Text = "Main Games";
-            // 
-            // trayHRtP
-            // 
-            this.trayHRtP.Image = global::Touhou_Launcher.Properties.Resources.Icon_th01;
-            this.trayHRtP.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayHRtP.Name = "trayHRtP";
-            this.trayHRtP.Size = new System.Drawing.Size(262, 38);
-            this.trayHRtP.Text = "Highly Responsive to Prayers";
-            this.trayHRtP.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // traySoEW
-            // 
-            this.traySoEW.Image = global::Touhou_Launcher.Properties.Resources.Icon_th02;
-            this.traySoEW.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.traySoEW.Name = "traySoEW";
-            this.traySoEW.Size = new System.Drawing.Size(262, 38);
-            this.traySoEW.Text = "Story of Eastern Wonderland";
-            this.traySoEW.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // trayPoDD
-            // 
-            this.trayPoDD.Image = global::Touhou_Launcher.Properties.Resources.Icon_th03;
-            this.trayPoDD.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayPoDD.Name = "trayPoDD";
-            this.trayPoDD.Size = new System.Drawing.Size(262, 38);
-            this.trayPoDD.Text = "Phantasmagoria of Dim. Dream";
-            this.trayPoDD.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // trayLLS
-            // 
-            this.trayLLS.Image = global::Touhou_Launcher.Properties.Resources.Icon_th04;
-            this.trayLLS.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayLLS.Name = "trayLLS";
-            this.trayLLS.Size = new System.Drawing.Size(262, 38);
-            this.trayLLS.Text = "Lotus Land Story";
-            this.trayLLS.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // trayMS
-            // 
-            this.trayMS.Image = global::Touhou_Launcher.Properties.Resources.Icon_th05;
-            this.trayMS.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayMS.Name = "trayMS";
-            this.trayMS.Size = new System.Drawing.Size(262, 38);
-            this.trayMS.Text = "Mystic Square";
-            this.trayMS.Click += new System.EventHandler(this.tray_Click);
             // 
             // trayEoSD
             // 
@@ -2282,18 +2379,86 @@
             this.trayUM.Text = "Unconnected Marketeers";
             this.trayUM.Click += new System.EventHandler(this.tray_Click);
             // 
-            // trayFighting
+            // traySpinoff
             // 
-            this.trayFighting.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.traySpinoff.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.trayStB,
+            this.trayDS,
+            this.trayGFW,
+            this.trayISC,
+            this.trayVD,
+            this.trayHBM});
+            this.traySpinoff.Name = "traySpinoff";
+            this.traySpinoff.Size = new System.Drawing.Size(200, 22);
+            this.traySpinoff.Text = "Spinoffs";
+            // 
+            // trayStB
+            // 
+            this.trayStB.Image = global::Touhou_Launcher.Properties.Resources.Icon_th095;
+            this.trayStB.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayStB.Name = "trayStB";
+            this.trayStB.Size = new System.Drawing.Size(203, 38);
+            this.trayStB.Text = "Shoot the Bullet";
+            this.trayStB.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayDS
+            // 
+            this.trayDS.Image = global::Touhou_Launcher.Properties.Resources.Icon_th125;
+            this.trayDS.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayDS.Name = "trayDS";
+            this.trayDS.Size = new System.Drawing.Size(203, 38);
+            this.trayDS.Text = "Double Spoiler";
+            this.trayDS.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayGFW
+            // 
+            this.trayGFW.Image = global::Touhou_Launcher.Properties.Resources.Icon_th128;
+            this.trayGFW.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayGFW.Name = "trayGFW";
+            this.trayGFW.Size = new System.Drawing.Size(203, 38);
+            this.trayGFW.Text = "Great Fairy Wars";
+            this.trayGFW.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayISC
+            // 
+            this.trayISC.Image = global::Touhou_Launcher.Properties.Resources.Icon_th143;
+            this.trayISC.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayISC.Name = "trayISC";
+            this.trayISC.Size = new System.Drawing.Size(203, 38);
+            this.trayISC.Text = "Impossible Spell Card";
+            this.trayISC.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayVD
+            // 
+            this.trayVD.Image = global::Touhou_Launcher.Properties.Resources.Icon_th165;
+            this.trayVD.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayVD.Name = "trayVD";
+            this.trayVD.Size = new System.Drawing.Size(203, 38);
+            this.trayVD.Text = "Violet Detector";
+            this.trayVD.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayHBM
+            // 
+            this.trayHBM.Image = global::Touhou_Launcher.Properties.Resources.Icon_th185;
+            this.trayHBM.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.trayHBM.Name = "trayHBM";
+            this.trayHBM.Size = new System.Drawing.Size(203, 38);
+            this.trayHBM.Text = "100th Black Market";
+            this.trayHBM.Click += new System.EventHandler(this.tray_Click);
+            // 
+            // trayTasofro
+            // 
+            this.trayTasofro.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.trayIaMP,
             this.traySWR,
             this.trayUoNL,
             this.trayHM,
             this.trayULiL,
-            this.trayAoCF});
-            this.trayFighting.Name = "trayFighting";
-            this.trayFighting.Size = new System.Drawing.Size(157, 22);
-            this.trayFighting.Text = "Fighting Games";
+            this.trayAoCF,
+            this.trayGI});
+            this.trayTasofro.Name = "trayTasofro";
+            this.trayTasofro.Size = new System.Drawing.Size(200, 22);
+            this.trayTasofro.Text = "Twilight Frontier Games";
             // 
             // trayIaMP
             // 
@@ -2349,103 +2514,44 @@
             this.trayAoCF.Text = "Antinomy of Common Flowers";
             this.trayAoCF.Click += new System.EventHandler(this.tray_Click);
             // 
-            // trayOther
-            // 
-            this.trayOther.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.trayStB,
-            this.trayDS,
-            this.trayGFW,
-            this.trayISC,
-            this.trayVD,
-            this.trayGI,
-            this.trayHBM});
-            this.trayOther.Name = "trayOther";
-            this.trayOther.Size = new System.Drawing.Size(157, 22);
-            this.trayOther.Text = "Other Games";
-            // 
-            // trayStB
-            // 
-            this.trayStB.Image = global::Touhou_Launcher.Properties.Resources.Icon_th095;
-            this.trayStB.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayStB.Name = "trayStB";
-            this.trayStB.Size = new System.Drawing.Size(203, 38);
-            this.trayStB.Text = "Shoot the Bullet";
-            this.trayStB.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // trayDS
-            // 
-            this.trayDS.Image = global::Touhou_Launcher.Properties.Resources.Icon_th125;
-            this.trayDS.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayDS.Name = "trayDS";
-            this.trayDS.Size = new System.Drawing.Size(203, 38);
-            this.trayDS.Text = "Double Spoiler";
-            this.trayDS.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // trayGFW
-            // 
-            this.trayGFW.Image = global::Touhou_Launcher.Properties.Resources.Icon_th128;
-            this.trayGFW.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayGFW.Name = "trayGFW";
-            this.trayGFW.Size = new System.Drawing.Size(203, 38);
-            this.trayGFW.Text = "Great Fairy Wars";
-            this.trayGFW.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // trayISC
-            // 
-            this.trayISC.Image = global::Touhou_Launcher.Properties.Resources.Icon_th143;
-            this.trayISC.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayISC.Name = "trayISC";
-            this.trayISC.Size = new System.Drawing.Size(203, 38);
-            this.trayISC.Text = "Impossible Spell Card";
-            this.trayISC.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // trayVD
-            // 
-            this.trayVD.Image = global::Touhou_Launcher.Properties.Resources.Icon_th165;
-            this.trayVD.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayVD.Name = "trayVD";
-            this.trayVD.Size = new System.Drawing.Size(203, 38);
-            this.trayVD.Text = "Violet Detector";
-            this.trayVD.Click += new System.EventHandler(this.tray_Click);
-            // 
             // trayGI
             // 
             this.trayGI.Image = global::Touhou_Launcher.Properties.Resources.Icon_th175;
             this.trayGI.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             this.trayGI.Name = "trayGI";
-            this.trayGI.Size = new System.Drawing.Size(203, 38);
+            this.trayGI.Size = new System.Drawing.Size(254, 38);
             this.trayGI.Text = "Gouyoku Ibun";
             this.trayGI.Click += new System.EventHandler(this.tray_Click);
             // 
             // trayCustom
             // 
             this.trayCustom.Name = "trayCustom";
-            this.trayCustom.Size = new System.Drawing.Size(157, 22);
+            this.trayCustom.Size = new System.Drawing.Size(200, 22);
             this.trayCustom.Text = "Custom Games";
             // 
             // trayRandom
             // 
             this.trayRandom.Name = "trayRandom";
-            this.trayRandom.Size = new System.Drawing.Size(157, 22);
+            this.trayRandom.Size = new System.Drawing.Size(200, 22);
             this.trayRandom.Text = "Random Game";
             this.trayRandom.Click += new System.EventHandler(this.btnRandom_Click);
             // 
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(154, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(197, 6);
             // 
             // trayOpen
             // 
             this.trayOpen.Name = "trayOpen";
-            this.trayOpen.Size = new System.Drawing.Size(157, 22);
+            this.trayOpen.Size = new System.Drawing.Size(200, 22);
             this.trayOpen.Text = "Open";
             this.trayOpen.Click += new System.EventHandler(this.MainForm_Show);
             // 
             // trayExit
             // 
             this.trayExit.Name = "trayExit";
-            this.trayExit.Size = new System.Drawing.Size(157, 22);
+            this.trayExit.Size = new System.Drawing.Size(200, 22);
             this.trayExit.Text = "Exit";
             this.trayExit.Click += new System.EventHandler(this.trayExit_Click);
             // 
@@ -2456,51 +2562,11 @@
             this.trayIcon.Text = "Touhou Launcher";
             this.trayIcon.DoubleClick += new System.EventHandler(this.MainForm_Show);
             // 
-            // btnHBM
-            // 
-            this.btnHBM.BackgroundImage = global::Touhou_Launcher.Properties.Resources.hbmg;
-            this.btnHBM.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.btnHBM.ContextMenuStrip = this.gameContextMenu;
-            this.btnHBM.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.btnHBM.FlatStyle = System.Windows.Forms.FlatStyle.Popup;
-            this.btnHBM.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.btnHBM.Location = new System.Drawing.Point(255, 53);
-            this.btnHBM.Name = "btnHBM";
-            this.btnHBM.Padding = new System.Windows.Forms.Padding(0, 0, 5, 0);
-            this.btnHBM.Size = new System.Drawing.Size(120, 44);
-            this.btnHBM.TabIndex = 6;
-            this.btnHBM.Text = "100th Black Market";
-            this.btnHBM.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnHBM.UseVisualStyleBackColor = true;
-            this.btnHBM.Click += new System.EventHandler(this.btn_Click);
-            // 
-            // trayHBM
-            // 
-            this.trayHBM.Image = global::Touhou_Launcher.Properties.Resources.Icon_th185;
-            this.trayHBM.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.trayHBM.Name = "trayHBM";
-            this.trayHBM.Size = new System.Drawing.Size(203, 38);
-            this.trayHBM.Text = "100th Black Market";
-            this.trayHBM.Click += new System.EventHandler(this.tray_Click);
-            // 
-            // chkHBM
-            // 
-            this.chkHBM.AutoSize = true;
-            this.chkHBM.Checked = true;
-            this.chkHBM.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chkHBM.Location = new System.Drawing.Point(46, 26);
-            this.chkHBM.Name = "chkHBM";
-            this.chkHBM.Size = new System.Drawing.Size(60, 17);
-            this.chkHBM.TabIndex = 6;
-            this.chkHBM.Text = "100BM";
-            this.chkHBM.UseVisualStyleBackColor = true;
-            this.chkHBM.CheckedChanged += new System.EventHandler(this.chkRandom_CheckedChanged);
-            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(534, 612);
+            this.ClientSize = new System.Drawing.Size(544, 582);
             this.Controls.Add(this.mainControl);
             this.Icon = global::Touhou_Launcher.Properties.Resources.thicon;
             this.MinimumSize = new System.Drawing.Size(440, 450);
@@ -2515,15 +2581,18 @@
             this.info.PerformLayout();
             this.settings.ResumeLayout(false);
             this.randomSettings.ResumeLayout(false);
-            this.otherRandom.ResumeLayout(false);
-            this.miscRandomPanel.ResumeLayout(false);
-            this.miscRandomPanel.PerformLayout();
-            this.fightingRandom.ResumeLayout(false);
-            this.fightingRandomPanel.ResumeLayout(false);
-            this.fightingRandomPanel.PerformLayout();
+            this.spinoffRandom.ResumeLayout(false);
+            this.spinoffRandomPanel.ResumeLayout(false);
+            this.spinoffRandomPanel.PerformLayout();
+            this.tasofroRandom.ResumeLayout(false);
+            this.tasofroRandomPanel.ResumeLayout(false);
+            this.tasofroRandomPanel.PerformLayout();
             this.mainRandom.ResumeLayout(false);
             this.mainRandomPanel.ResumeLayout(false);
             this.mainRandomPanel.PerformLayout();
+            this.pc98Random.ResumeLayout(false);
+            this.pc98RandomPanel.ResumeLayout(false);
+            this.pc98RandomPanel.PerformLayout();
             this.launcherSettings.ResumeLayout(false);
             this.launcherSettings.PerformLayout();
             this.replays.ResumeLayout(false);
@@ -2533,12 +2602,14 @@
             this.customGames.PerformLayout();
             this.mainControl.ResumeLayout(false);
             this.games.ResumeLayout(false);
-            this.otherGroup.ResumeLayout(false);
-            this.miscLayoutPanel.ResumeLayout(false);
-            this.fightingGroup.ResumeLayout(false);
-            this.fightingLayoutPanel.ResumeLayout(false);
+            this.spinoffGroup.ResumeLayout(false);
+            this.spinoffLayoutPanel.ResumeLayout(false);
+            this.tasofroGroup.ResumeLayout(false);
+            this.tasofroLayoutPanel.ResumeLayout(false);
             this.mainGroup.ResumeLayout(false);
             this.mainLayoutPanel.ResumeLayout(false);
+            this.pc98Group.ResumeLayout(false);
+            this.pc98LayoutPanel.ResumeLayout(false);
             this.trayMenu.ResumeLayout(false);
             this.ResumeLayout(false);
 
@@ -2583,9 +2654,9 @@
         private System.Windows.Forms.TreeView customTree;
         private System.Windows.Forms.TabControl mainControl;
         private System.Windows.Forms.TabPage games;
-        private System.Windows.Forms.GroupBox mainGroup;
+        private System.Windows.Forms.GroupBox pc98Group;
         private System.Windows.Forms.Button btnHRtP;
-        private System.Windows.Forms.FlowLayoutPanel mainLayoutPanel;
+        private System.Windows.Forms.FlowLayoutPanel pc98LayoutPanel;
         private System.Windows.Forms.Button btnSoEW;
         private System.Windows.Forms.Button btnRandom;
         private System.Windows.Forms.Button btnPoDD;
@@ -2602,16 +2673,16 @@
         private System.Windows.Forms.Button btnDDC;
         private System.Windows.Forms.Button btnLoLK;
         private System.Windows.Forms.Button btnHSiFS;
-        private System.Windows.Forms.GroupBox fightingGroup;
-        private System.Windows.Forms.FlowLayoutPanel fightingLayoutPanel;
+        private System.Windows.Forms.GroupBox mainGroup;
+        private System.Windows.Forms.FlowLayoutPanel mainLayoutPanel;
         private System.Windows.Forms.Button btnIaMP;
         private System.Windows.Forms.Button btnSWR;
         private System.Windows.Forms.Button btnUoNL;
         private System.Windows.Forms.Button btnHM;
         private System.Windows.Forms.Button btnULiL;
         private System.Windows.Forms.Button btnAoCF;
-        private System.Windows.Forms.GroupBox otherGroup;
-        private System.Windows.Forms.FlowLayoutPanel miscLayoutPanel;
+        private System.Windows.Forms.GroupBox tasofroGroup;
+        private System.Windows.Forms.FlowLayoutPanel tasofroLayoutPanel;
         private System.Windows.Forms.Button btnStB;
         private System.Windows.Forms.Button btnDS;
         private System.Windows.Forms.Button btnGFW;
@@ -2623,23 +2694,23 @@
         private System.Windows.Forms.GroupBox randomSettings;
         private System.Windows.Forms.Button randomNone;
         private System.Windows.Forms.Button randomAll;
-        private System.Windows.Forms.GroupBox otherRandom;
-        private System.Windows.Forms.FlowLayoutPanel miscRandomPanel;
+        private System.Windows.Forms.GroupBox tasofroRandom;
+        private System.Windows.Forms.FlowLayoutPanel tasofroRandomPanel;
         private System.Windows.Forms.CheckBox chkStB;
         private System.Windows.Forms.CheckBox chkDS;
         private System.Windows.Forms.CheckBox chkGFW;
         private System.Windows.Forms.CheckBox chkISC;
         private System.Windows.Forms.CheckBox chkVD;
-        private System.Windows.Forms.GroupBox fightingRandom;
-        private System.Windows.Forms.FlowLayoutPanel fightingRandomPanel;
+        private System.Windows.Forms.GroupBox mainRandom;
+        private System.Windows.Forms.FlowLayoutPanel mainRandomPanel;
         private System.Windows.Forms.CheckBox chkIaMP;
         private System.Windows.Forms.CheckBox chkSWR;
         private System.Windows.Forms.CheckBox chkUoNL;
         private System.Windows.Forms.CheckBox chkHM;
         private System.Windows.Forms.CheckBox chkULiL;
         private System.Windows.Forms.CheckBox chkAoCF;
-        private System.Windows.Forms.GroupBox mainRandom;
-        private System.Windows.Forms.FlowLayoutPanel mainRandomPanel;
+        private System.Windows.Forms.GroupBox pc98Random;
+        private System.Windows.Forms.FlowLayoutPanel pc98RandomPanel;
         private System.Windows.Forms.CheckBox chkHRtP;
         private System.Windows.Forms.CheckBox chkSoEW;
         private System.Windows.Forms.CheckBox chkPoDD;
@@ -2666,41 +2737,19 @@
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.ContextMenuStrip trayMenu;
-        private System.Windows.Forms.ToolStripMenuItem trayMain;
+        private System.Windows.Forms.ToolStripMenuItem trayPC98;
         private System.Windows.Forms.ToolStripMenuItem trayHRtP;
         private System.Windows.Forms.ToolStripMenuItem traySoEW;
         private System.Windows.Forms.ToolStripMenuItem trayPoDD;
         private System.Windows.Forms.ToolStripMenuItem trayLLS;
         private System.Windows.Forms.ToolStripMenuItem trayMS;
-        private System.Windows.Forms.ToolStripMenuItem trayEoSD;
-        private System.Windows.Forms.ToolStripMenuItem trayPCB;
-        private System.Windows.Forms.ToolStripMenuItem trayIN;
-        private System.Windows.Forms.ToolStripMenuItem trayPoFV;
-        private System.Windows.Forms.ToolStripMenuItem trayMoF;
-        private System.Windows.Forms.ToolStripMenuItem traySA;
-        private System.Windows.Forms.ToolStripMenuItem trayUFO;
-        private System.Windows.Forms.ToolStripMenuItem trayTD;
-        private System.Windows.Forms.ToolStripMenuItem trayDDC;
-        private System.Windows.Forms.ToolStripMenuItem trayLoLK;
-        private System.Windows.Forms.ToolStripMenuItem trayHSiFS;
-        private System.Windows.Forms.ToolStripMenuItem trayFighting;
-        private System.Windows.Forms.ToolStripMenuItem trayOther;
+        private System.Windows.Forms.ToolStripMenuItem trayMain;
+        private System.Windows.Forms.ToolStripMenuItem trayTasofro;
         private System.Windows.Forms.ToolStripMenuItem trayCustom;
         private System.Windows.Forms.ToolStripMenuItem trayRandom;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem trayOpen;
         private System.Windows.Forms.ToolStripMenuItem trayExit;
-        private System.Windows.Forms.ToolStripMenuItem trayIaMP;
-        private System.Windows.Forms.ToolStripMenuItem traySWR;
-        private System.Windows.Forms.ToolStripMenuItem trayUoNL;
-        private System.Windows.Forms.ToolStripMenuItem trayHM;
-        private System.Windows.Forms.ToolStripMenuItem trayULiL;
-        private System.Windows.Forms.ToolStripMenuItem trayAoCF;
-        private System.Windows.Forms.ToolStripMenuItem trayStB;
-        private System.Windows.Forms.ToolStripMenuItem trayDS;
-        private System.Windows.Forms.ToolStripMenuItem trayGFW;
-        private System.Windows.Forms.ToolStripMenuItem trayISC;
-        private System.Windows.Forms.ToolStripMenuItem trayVD;
         private System.Windows.Forms.Label label4;
         public System.Windows.Forms.ToolTip toolTip;
         private System.Windows.Forms.NotifyIcon trayIcon;
@@ -2719,16 +2768,43 @@
         private System.Windows.Forms.ToolStripMenuItem bannerToolStripMenuItem;
         private System.Windows.Forms.Button btnWBaWC;
         private System.Windows.Forms.CheckBox chkWBaWC;
-        private System.Windows.Forms.ToolStripMenuItem trayWBaWC;
         private System.Windows.Forms.Button btnUM;
         private System.Windows.Forms.CheckBox chkUM;
-        private System.Windows.Forms.ToolStripMenuItem trayUM;
         private System.Windows.Forms.CheckBox chkGI;
         private System.Windows.Forms.Button btnGI;
         private System.Windows.Forms.ToolStripMenuItem trayGI;
         private System.Windows.Forms.Button btnHBM;
-        private System.Windows.Forms.ToolStripMenuItem trayHBM;
         private System.Windows.Forms.CheckBox chkHBM;
+        private System.Windows.Forms.ToolStripMenuItem trayEoSD;
+        private System.Windows.Forms.ToolStripMenuItem trayPCB;
+        private System.Windows.Forms.ToolStripMenuItem trayIN;
+        private System.Windows.Forms.ToolStripMenuItem trayPoFV;
+        private System.Windows.Forms.ToolStripMenuItem trayMoF;
+        private System.Windows.Forms.ToolStripMenuItem traySA;
+        private System.Windows.Forms.ToolStripMenuItem trayUFO;
+        private System.Windows.Forms.ToolStripMenuItem trayTD;
+        private System.Windows.Forms.ToolStripMenuItem trayDDC;
+        private System.Windows.Forms.ToolStripMenuItem trayLoLK;
+        private System.Windows.Forms.ToolStripMenuItem trayHSiFS;
+        private System.Windows.Forms.ToolStripMenuItem trayWBaWC;
+        private System.Windows.Forms.ToolStripMenuItem trayUM;
+        private System.Windows.Forms.ToolStripMenuItem trayIaMP;
+        private System.Windows.Forms.ToolStripMenuItem traySWR;
+        private System.Windows.Forms.ToolStripMenuItem trayUoNL;
+        private System.Windows.Forms.ToolStripMenuItem trayHM;
+        private System.Windows.Forms.ToolStripMenuItem trayULiL;
+        private System.Windows.Forms.ToolStripMenuItem trayAoCF;
+        private System.Windows.Forms.GroupBox spinoffGroup;
+        private System.Windows.Forms.FlowLayoutPanel spinoffLayoutPanel;
+        private System.Windows.Forms.GroupBox spinoffRandom;
+        private System.Windows.Forms.FlowLayoutPanel spinoffRandomPanel;
+        private System.Windows.Forms.ToolStripMenuItem traySpinoff;
+        private System.Windows.Forms.ToolStripMenuItem trayStB;
+        private System.Windows.Forms.ToolStripMenuItem trayDS;
+        private System.Windows.Forms.ToolStripMenuItem trayGFW;
+        private System.Windows.Forms.ToolStripMenuItem trayISC;
+        private System.Windows.Forms.ToolStripMenuItem trayVD;
+        private System.Windows.Forms.ToolStripMenuItem trayHBM;
     }
 }
 

--- a/Touhou Launcher/MainForm.cs
+++ b/Touhou Launcher/MainForm.cs
@@ -1003,7 +1003,8 @@ namespace Touhou_Launcher
                 txtbox.BackColor = SystemColors.Window;
                 txtbox.Text = file;
                 curCfg.np2Dir = np2Dir.Text;
-                curCfg.crapDir = Path.GetDirectoryName(crapDir.Text).TrimEnd("\\bin".ToCharArray());
+                string crapPath = Path.GetDirectoryName(crapDir.Text);
+                curCfg.crapDir = (Directory.Exists(crapPath + "\\bin") || !crapPath.EndsWith("\\bin")) ? crapPath : crapPath.Substring(0, crapPath.LastIndexOf("\\bin"));
             }
         }
 
@@ -1013,8 +1014,8 @@ namespace Touhou_Launcher
             {
                 ((TextBox)sender).BackColor = SystemColors.Window;
                 curCfg.np2Dir = np2Dir.Text;
-                string crapPath = crapDir.Text == "" ? "" : Path.GetDirectoryName(crapDir.Text);
-                curCfg.crapDir = Directory.Exists(crapPath + "\\bin") ? crapPath : crapPath.TrimEnd("\\bin".ToCharArray());
+                string crapPath = Path.GetDirectoryName(crapDir.Text);
+                curCfg.crapDir = (Directory.Exists(crapPath + "\\bin") || !crapPath.EndsWith("\\bin")) ? crapPath : crapPath.Substring(0, crapPath.LastIndexOf("\\bin"));
                 curCfg.StartingRepo = crapStartingRepo.Text;
             }
             else
@@ -1032,7 +1033,9 @@ namespace Touhou_Launcher
             if (curCfg.crapDir != "")
             {
                 string procDir = curCfg.crapDir + "\\bin\\thcrap_configure.exe";
-                if (File.Exists(procDir))
+                if (!File.Exists(procDir))
+                    MessageBox.Show(rm.GetString("errorcrapNotFound"));
+                else
                     startProcess(procDir);
             }
         }

--- a/Touhou Launcher/MainForm.cs
+++ b/Touhou Launcher/MainForm.cs
@@ -109,7 +109,7 @@ namespace Touhou_Launcher
         private FormWindowState lastState = FormWindowState.Normal;
         private const int mainGameCount = 18;
         private const int fightingGameCount = 6;
-        private const int otherGameCount = 5;
+        private const int otherGameCount = 6;
         private const int totalGameCount = mainGameCount + fightingGameCount + otherGameCount;
         public static Configs curCfg = Configs.Load();
         public static System.Resources.ResourceManager rm;
@@ -122,7 +122,7 @@ namespace Touhou_Launcher
         };
         public static List<int> idToNumber = new List<int>
         {
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 75, 105, 123, 135, 145, 155, 95, 125, 128, 143, 165
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 75, 105, 123, 135, 145, 155, 95, 125, 128, 143, 165, 175
         };
         public static Dictionary<string, int> nameToID = new Dictionary<string, int>
         {
@@ -154,7 +154,8 @@ namespace Touhou_Launcher
             {"DS", 25},
             {"GFW", 26},
             {"ISC", 27},
-            {"VD", 28}
+            {"VD", 28},
+            {"GI", 29}
         };
 
         public static IEnumerable<Control> GetAll(Control control, Type type)

--- a/Touhou Launcher/MainForm.cs
+++ b/Touhou Launcher/MainForm.cs
@@ -519,6 +519,8 @@ namespace Touhou_Launcher
 
         public MainForm()
         {
+            System.Net.ServicePointManager.Expect100Continue = true;
+            System.Net.ServicePointManager.SecurityProtocol = (System.Net.SecurityProtocolType)3072;
             InitializeComponent();
             if (totalGameCount > curCfg.gameCFG.Length)
             {
@@ -886,8 +888,7 @@ namespace Touhou_Launcher
         {
             if (e.KeyCode == Keys.Enter)
             {
-                gensokyoReplays.Checked = false;
-                royalflareReplays.Checked = false;
+                maribelReplays.Checked = false;
                 appspotReplays.Checked = false;
                 Replays_CheckedChanged(sender, new EventArgs());
             }

--- a/Touhou Launcher/MainForm.cs
+++ b/Touhou Launcher/MainForm.cs
@@ -85,7 +85,7 @@ namespace Touhou_Launcher
             public int language = 0;
             public string np2Dir = "";
             public string crapDir = "";
-            public string StartingRepo = @"https://mirrors.thpatch.net/nmlgc/";
+            public string StartingRepo = @"https://srv.thpatch.net/";
             public Configs()
             {
                 for (int i = 0; i < gameCFG.Length ; i++)

--- a/Touhou Launcher/MainForm.cs
+++ b/Touhou Launcher/MainForm.cs
@@ -385,6 +385,10 @@ namespace Touhou_Launcher
             {
                 tMenu.Text = rm.GetString(tMenu.Name.Substring(4));
             }
+            foreach (ToolStripMenuItem tMenu in traySpinoff.DropDownItems)
+            {
+                tMenu.Text = rm.GetString(tMenu.Name.Substring(4));
+            }
             foreach (ToolStripMenuItem tMenu in trayTasofro.DropDownItems)
             {
                 tMenu.Text = rm.GetString(tMenu.Name.Substring(4));

--- a/Touhou Launcher/MainForm.cs
+++ b/Touhou Launcher/MainForm.cs
@@ -377,15 +377,15 @@ namespace Touhou_Launcher
                         languageBox.SelectedIndex = 0;
                     break;
             }
+            foreach (ToolStripMenuItem tMenu in trayPC98.DropDownItems)
+            {
+                tMenu.Text = rm.GetString(tMenu.Name.Substring(4));
+            }
             foreach (ToolStripMenuItem tMenu in trayMain.DropDownItems)
             {
                 tMenu.Text = rm.GetString(tMenu.Name.Substring(4));
             }
-            foreach (ToolStripMenuItem tMenu in trayFighting.DropDownItems)
-            {
-                tMenu.Text = rm.GetString(tMenu.Name.Substring(4));
-            }
-            foreach (ToolStripMenuItem tMenu in trayOther.DropDownItems)
+            foreach (ToolStripMenuItem tMenu in trayTasofro.DropDownItems)
             {
                 tMenu.Text = rm.GetString(tMenu.Name.Substring(4));
             }
@@ -416,16 +416,18 @@ namespace Touhou_Launcher
             {
                 tab.Text = rm.GetString(tab.Name);
             }
+            trayPC98.Text = rm.GetString("pc98Group");
             trayMain.Text = rm.GetString("mainGroup");
-            trayFighting.Text = rm.GetString("fightingGroup");
-            trayOther.Text = rm.GetString("otherGroup");
+            traySpinoff.Text = rm.GetString("spinoffGroup");
+            trayTasofro.Text = rm.GetString("tasofroGroup");
             trayCustom.Text = rm.GetString("customGames");
             trayRandom.Text = rm.GetString("trayRandom");
             trayOpen.Text = rm.GetString("trayOpen");
             trayExit.Text = rm.GetString("trayExit");
+            pc98Group.Text = rm.GetString("pc98Group");
             mainGroup.Text = rm.GetString("mainGroup");
-            fightingGroup.Text = rm.GetString("fightingGroup");
-            otherGroup.Text = rm.GetString("otherGroup");
+            spinoffGroup.Text = rm.GetString("spinoffGroup");
+            tasofroGroup.Text = rm.GetString("tasofroGroup");
             configureToolStripMenuItem.Text = rm.GetString("configureToolStripMenuItem");
             buttonToolStripMenuItem.Text = rm.GetString("buttonToolStripMenuItem");
             bannerToolStripMenuItem.Text = rm.GetString("bannerToolStripMenuItem");
@@ -453,9 +455,10 @@ namespace Touhou_Launcher
             randomLabel.Text = rm.GetString("randomLabel");
             randomAll.Text = rm.GetString("randomAll");
             randomNone.Text = rm.GetString("randomNone");
+            pc98Random.Text = rm.GetString("pc98Group");
             mainRandom.Text = rm.GetString("mainGroup");
-            fightingRandom.Text = rm.GetString("fightingGroup");
-            otherRandom.Text = rm.GetString("otherGroup");
+            spinoffRandom.Text = rm.GetString("spinoffGroup");
+            tasofroRandom.Text = rm.GetString("tasofroGroup");
             this.Text = rm.GetString("Title");
         }
 

--- a/Touhou Launcher/MainForm.cs
+++ b/Touhou Launcher/MainForm.cs
@@ -670,6 +670,10 @@ namespace Touhou_Launcher
             {
                 customAddItem(FileBrowser(rm.GetString("gameSelectTitle"), rm.GetString("executableFilter") + " (*.exe, *.bat, *.lnk)|*.exe;*.bat;*.lnk|" + rm.GetString("allFilter") + " (*.*)|*.*", true));
             }
+			else
+			{
+				MessageBox.Show(rm.GetString("errorNoCategorySelected"));
+			}
         }
 
         private void customTree_NodeMouseClick(object sender, TreeNodeMouseClickEventArgs e)

--- a/Touhou Launcher/MainForm.cs
+++ b/Touhou Launcher/MainForm.cs
@@ -109,7 +109,7 @@ namespace Touhou_Launcher
         private FormWindowState lastState = FormWindowState.Normal;
         private const int mainGameCount = 18;
         private const int fightingGameCount = 6;
-        private const int otherGameCount = 6;
+        private const int otherGameCount = 7;
         private const int totalGameCount = mainGameCount + fightingGameCount + otherGameCount;
         public static Configs curCfg = Configs.Load();
         public static System.Resources.ResourceManager rm;
@@ -122,7 +122,7 @@ namespace Touhou_Launcher
         };
         public static List<int> idToNumber = new List<int>
         {
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 75, 105, 123, 135, 145, 155, 95, 125, 128, 143, 165, 175
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 75, 105, 123, 135, 145, 155, 95, 125, 128, 143, 165, 175, 185
         };
         public static Dictionary<string, int> nameToID = new Dictionary<string, int>
         {
@@ -155,7 +155,8 @@ namespace Touhou_Launcher
             {"GFW", 26},
             {"ISC", 27},
             {"VD", 28},
-            {"GI", 29}
+            {"GI", 29},
+            {"HBM", 30}
         };
 
         public static IEnumerable<Control> GetAll(Control control, Type type)

--- a/Touhou Launcher/Properties/AssemblyInfo.cs
+++ b/Touhou Launcher/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.0.2.0")]
+[assembly: AssemblyFileVersion("1.0.2.0")]

--- a/Touhou Launcher/Properties/AssemblyInfo.cs
+++ b/Touhou Launcher/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/Touhou Launcher/Properties/Resources.Designer.cs
+++ b/Touhou Launcher/Properties/Resources.Designer.cs
@@ -183,6 +183,26 @@ namespace Touhou_Launcher.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
+        public static System.Drawing.Bitmap gi {
+            get {
+                object obj = ResourceManager.GetObject("gi", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        public static System.Drawing.Bitmap gig {
+            get {
+                object obj = ResourceManager.GetObject("gig", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
         public static System.Drawing.Bitmap hm {
             get {
                 object obj = ResourceManager.GetObject("hm", resourceCulture);
@@ -546,6 +566,16 @@ namespace Touhou_Launcher.Properties {
         public static System.Drawing.Bitmap Icon_th17 {
             get {
                 object obj = ResourceManager.GetObject("Icon_th17", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        public static System.Drawing.Bitmap Icon_th175 {
+            get {
+                object obj = ResourceManager.GetObject("Icon_th175", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Touhou Launcher/Properties/Resources.Designer.cs
+++ b/Touhou Launcher/Properties/Resources.Designer.cs
@@ -203,6 +203,26 @@ namespace Touhou_Launcher.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
+        public static System.Drawing.Bitmap hbm {
+            get {
+                object obj = ResourceManager.GetObject("hbm", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        public static System.Drawing.Bitmap hbmg {
+            get {
+                object obj = ResourceManager.GetObject("hbmg", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
         public static System.Drawing.Bitmap hm {
             get {
                 object obj = ResourceManager.GetObject("hm", resourceCulture);
@@ -586,6 +606,16 @@ namespace Touhou_Launcher.Properties {
         public static System.Drawing.Bitmap Icon_th18 {
             get {
                 object obj = ResourceManager.GetObject("Icon_th18", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
+        public static System.Drawing.Bitmap Icon_th185 {
+            get {
+                object obj = ResourceManager.GetObject("Icon_th185", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Touhou Launcher/Properties/Resources.resx
+++ b/Touhou Launcher/Properties/Resources.resx
@@ -17192,7 +17192,7 @@
   <data name="aocf" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADr0AAA69AUf7kK0AAEN9SURBVHhePbx3XFVX3r596L333rsUQRQUC/aGDRFUUIoo
+        YQUAAAAJcEhZcwAADrwAAA68AZW8ckkAAEN9SURBVHhePbx3XFVX3r596L333rsUQRQUC/aGDRFUUIoo
         vStFqkhVioCg2BUrNuy9azSxJ5ZoTGJ6MimTTDJPJjOZ6/0eMu/vj/XZp+xTWPe62977oPCxqWPGmJOE
         uG/C3bweB6NcjDSGYK5ljrtBPD7mNfLYCkxNRmPnEoG9+1g8QhaxdPMjElSKKdBrYHXN+0wqvIn3mGaG
         z95LdO0LmmYdp2TydkrznzJ0dAPB5ok8Kf2Gt49gR8e3VEzvZ27xE7zdarA3no2ethM6mkbYGs0k0LUV
@@ -17486,7 +17486,7 @@
   <data name="aocfg" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADr0AAA69AUf7kK0AAAAGYktHRAD/AP8A/6C9p5MAAB+XSURBVHhefdzlzx9FFwbg
+        YQUAAAAJcEhZcwAADrwAAA68AZW8ckkAAAAGYktHRAD/AP8A/6C9p5MAAB+XSURBVHhefdzlzx9FFwbg
         xZ3iLi1W3LV4BYq7u7u7FmhpoRSKuxd3d/fgGggSAgkJH+BvGLjO+97N5knDh8nub3d25sy5Zc7uU+iW
         WWaZtvXWW7fVVlutLbXUUm2RRRZps802W5t99tnbQgst1JZeeum28MILt/nnn78NHjy46b/WWmu1yZMn
         t8UXX7ytuOKK7dJLL20nnnhi23TTTduOO+7YLrjggnbwwQe3Pffcs5199tlts802q7Gvvfba9t1337Vb
@@ -17627,7 +17627,7 @@
   <data name="vd" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADr0AAA69AUf7kK0AAEH3SURBVHheVZwHWBRp+u0bmm7oQJNzRoIigoGcRIJgQImK
+        YQUAAAAJcEhZcwAADrwAAA68AZW8ckkAAEH3SURBVHheVZwHWBRp+u0bmm7oQJNzRoIigoGcRIJgQImK
         iATFnHOOo4455zzGUcfsOOaIilkxgDmHccZJuzs7u//d/+++1c7uvZfn+Z6qru6urv7Oe857TlU1qtCY
         Axj9N2AfvBm3yC14xq4jo+oETqkjadF5ArrgODS+4egbJGLh2QKr0HicQ2Xp6UPmwBFE5w0iOXccmy++
         JCy3lAYhjSgIaUyhkzN5OiOlBkfKDU50NThQbu9Chb0r5XYudDU6UOnoRqnRkW62zpSZXGTpZB5lyvM6
@@ -17915,7 +17915,7 @@
   <data name="vdg" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADr0AAA69AUf7kK0AAAAGYktHRAD/AP8A/6C9p5MAAB5xSURBVHheddtjsC7J0gXg
+        YQUAAAAJcEhZcwAADrwAAA68AZW8ckkAAAAGYktHRAD/AP8A/6C9p5MAAB5xSURBVHheddtjsC7J0gXg
         d2zbtm3btm3btm2esW3btm1PxCgmpu48eb+1o8/5zv2R0d3VhaxcuTKz+t27N++887bJJpusTT311G3m
         mWduc801V9t0003bPPPM01ZeeeU20UQTtXHGGaeuY4wxRl0nnXTSNvroo7fNNtusLbfccm2FFVZoDzzw
         QFtqqaXa5JNP3maaaabqN9ZYY7XxxhuvjT/++HWdeOKJS7zTNskkk9R1ggkmaBNOOGFdcz/uuOPWuuYY
@@ -18051,7 +18051,7 @@
   <data name="wbawc" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wAAADsABataJCQAAMSVJREFUeF69fAd4HWeVtgkhWXoWCJ0NZdnN/vwsZOlhNyTsEggdAqRASCEJcXpv
+        vgAADr4B6kKxwAAAMSVJREFUeF69fAd4HWeVtgkhWXoWCJ0NZdnN/vwsZOlhNyTsEggdAqRASCEJcXpv
         jnuTJRfJvfcWF1myZPXee73SLbq9996vpPd/z0hWHMeBhN39Pz/H38zcmbkz33vec97zzVzNiyZTmMpm
         MB2LYKjqHIq1Fmz1pOGOJYBcBkG9Bp2H92E6HASyKUzGwsr2tMWAoEEH71APguksplNJZDNphBx2RCY0
         sNM0nU3oaqpFld6CnjE1TDotjnkT2OKMIeJx47/TrIMq1G7chfqt+9Cwbf/fZPVi2w+gfuch1G7ajYpV
@@ -18267,7 +18267,7 @@
   <data name="wbawc2" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsAAAA7AAWrWiQkAAAAGYktHRAD/AP8A/6C9p5MAAC30SURBVHhexZwHfJzVme6F
+        YQUAAAAJcEhZcwAADr4AAA6+AepCscAAAAAGYktHRAD/AP8A/6C9p5MAAC30SURBVHhexZwHfJzVme6F
         yYaUS5KbTTbhprMhIdncDSQsKSQhlECATSAQeg0ldGwMNti4W7ZkSZYN7rg3XOUiWb333kcjjTSj0fTe
         u9pzn/dTwTJ2Qkiy9/x+j883X5uZ8z9vO9/ISa5wBIhGkIhGEY+E4e3twmgoAHtbPfQV+WgrzsHpAQNq
         BwZhbm1Cr82J7fYINlpDcAzp8Y9q+vpmFGRuRdmWPf8QlU5tb9uHkq37kJe+Adkr03A6OQPZVA63c1as
@@ -18470,7 +18470,7 @@
   <data name="wbawc2g" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsAAAA7AAWrWiQkAABk+SURBVHhevdwDsGXHFgbgkxdXkgortm1ObNvWxLZt287E
+        YQUAAAAJcEhZcwAADr4AAA6+AepCscAAABk+SURBVHhevdwDsGXHFgbgkxdXkgortm1ObNvWxLZt287E
         tm3btm33q68r/62dM+fOu5lJXlet6r3bvf6Fxj6n9fXXX5eff/65/PDDD5Vef/31Gj/33HPloYceKnfe
         eWd58skny/PPP1/T3n333fLss8/WNM//VHjqqafK2WefXS688MJ/lC666KIan3766eWEE04oJ554YiXP
         6Pjjjy/HHXdcOemkk8q5555bHnnkkfLqq6/W+b744ot9kfQXXnihxuEJSpoyL730Uo033HDDct5551V+
@@ -18584,7 +18584,7 @@
   <data name="wbawcg" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsAAAA7AAWrWiQkAAAAGYktHRAD/AP8A/6C9p5MAABqXSURBVHhetdwD1CVXswbg
+        YQUAAAAJcEhZcwAADr4AAA6+AepCscAAAAAGYktHRAD/AP8A/6C9p5MAABqXSURBVHhetdwD1CVXswbg
         E9u2nRVzYtt2sjKxba7Ytie2bdu2bXvf++x/3u92zpzJfN/Nn71Wre7erKq3qja6z2n98MMP5bfffis/
         /vhjueuuu8oTTzxRnnvuufL111+XP/74o7zzzjvlyiuvLN9//32tp778jz76qLz77rvlpZdeqnm//PJL
         pY8//ri2eeONN8pjjz1W7rnnnvLss89Weu2118rLL79cnn766fL555+Xf5KM26dPn3LhhReWiy666B/R
@@ -18759,7 +18759,7 @@
   <data name="um" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAIAAAAhGetkAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQflAxUOCBUFoL4F
+        YQUAAAAJcEhZcwAADr8AAA6/ATgFUyQAAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQflAxUOCBUFoL4F
         AAA4QElEQVRoQ4WaBVRb2b/vD26l0BZKFUpLXabTf92m7u3UnbpQSot7cXd395DgECEECMGCSyAJBAmW
         IAnBNcl5G5g7d+68d9c767vO2tmWsz/7d75776xAgik+3M6G6Vy4fRym85ZEHV0SjQM3ceAyNtzAghv7
         5ys4MGlIUDTII7InCod4JUPT+YzJ6LapIjq/lcFLJU7R2eMNTGYsrjska8AX0YsgdWXWdhqm0iPS6fEJ
@@ -19006,7 +19006,7 @@
   <data name="umg" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAIAAAAhGetkAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQflAxUOCQh/veOd
+        YQUAAAAJcEhZcwAADr8AAA6/ATgFUyQAAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQflAxUOCQh/veOd
         AAAdxElEQVRoQ43adbSW1bbH8QfjgGK3YqAYSCggynYrCAKiUgICiqDScQEDBERRsLuxu7v7GpiYF+zE
         QBTwYNdRx5Dzefdv8559BMa4649nrHc9K+b8zt+aaz0bit9///2bb75ZtGhRnso/l5QFCxbMnTt3/vz5
         Kp999tnnn3/+ySefvL+kvPfeey+//PIHH3ywcOHC11577auvvtJnxowZ/1tVXnjhhZkzZ956662PP/74
@@ -19140,7 +19140,7 @@
   <data name="Icon_th18" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAAGYktHRAD/AP0A8DOGbmwAAAAHdElNRQflBBQMAhiI5kUp
+        YQUAAAAJcEhZcwAACxAAAAsQAa0jvXUAAAAGYktHRAD/AP0A8DOGbmwAAAAHdElNRQflBBQMAhiI5kUp
         AAALXklEQVRYR3VXCVhTVxa+YLEiRClYlakrjLhUxa2WWlCrjq22Y8fiTG21LjioYLVulanValEUFFcU
         q8KwyhrZlEUIoOyShCSEHWQTkF0MEEJC8s99j5Bi7ZzvO9+99+W9+//33LOF4E+kubkZ5ubmIIS8piYm
         JggKCsLy5ct1z8zMzDB37jzMnz+f/d3Q0BB2dnZwdnZGaFgYQrmxeHf8BBgZG+PmHX8kpmUjJjEV06Zb
@@ -19190,6 +19190,361 @@
         uK4gkxzTMWl7DNZG+uF2dBAqc5LQJkqGNPQnuO9cyoJzDAlGGvz+V435eNbAJ7oNh+ZDI3Og4WvG44fW
         Q89MLD7G7C9Pg2zY64lH98PR90xAS20BitPj8Cw9FMWhLti09kOafvXw5TL68eRB8L+aEyyeM4Hd5PO/
         22OJlSE7N9AfJGM88wtMdEiD8awNg2s6Dl8PfzbRIQ3/A+cTdcYeIZMaAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="gi" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAACxEAAAsRAX9kX5EAAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQflCwIHKSwkVTyG
+        AAAxc0lEQVR4XpWbBZiW1db3h5mhu7uUECVEWqS7e+juzqG7O6SkQVJKQJAGQQlRQkVSRDmoiGKhHj3G
+        //3972cexHPe+D6ua7F777VXr30/E6H/49+5c+eUO1cuRUREKCIe4PL/B+LFU8p4kaodHaXTCRLotwTx
+        gYT6PSq+fokXpe8Y+5R9P4qIp0+Y+21EpH6k7xf6/kn7Z+AhY/fpv0X9GvAZY99T/gg8mhMZXz+lSa/f
+        ChbRr6XL6n6OHLoRHa0rXgf8gz3vRlKy1+fM/572d5FRekD5gPEH4PIFde9/m/IcY28AH1N/i/Ft1C9F
+        ROld1p9mzinA5Zm4+pvgdIr7nqE8S/s68z9hz1vAp8HeUboDHI2MVu3ICKVgjulTtVo1XbhwQXfv3lXT
+        Jk2UAPqE6PZ3Oj7zzDM6f/68/vjjjzjO/L/9+18ZPHv27P9kqttxEC8Oyf8J0jLehwudgfi/RkXpV9q/
+        RsbTv6IACPczhPsGgn1KaaJ+BgEexovWP2kHcynNQDPjLvtZCAzf0P5nsD4eAkJf/Gj99FRB/dy5q9bE
+        NNfMpjH6YfgIff1kXn0Aoe+kTK1/FSmiX54tqq/SpNVV5j/MnkMqWFA/pU2rB+B2j30+Y8+LlIfA8Rhw
+        DoG4BRyhby3wBnCCOQco93P2MfBz+yR1wztBPVI7KV+GPpuZtwVmnmePq9Q/4A4W4q+Z6zO6UE8dR6sG
+        DRtqz57d2rFju1q0aK5Ixv6dnobY2Fj98ssvcRz6v//9jwzu1KnTfx7wGHP/fexvzKbeBe25xEW/4jJf
+        cOl7XPIh636Mgx+Yc5++z5nzGeOfoh0f0nebi3vsR9Y9pDQTvwXuQqhAC5n7Beut+YYvmf9Fzhy63buX
+        8mfKpPicaxx61aottW2juxky6HcYvrlNa701eoR+b9tOH+XIqlvNmujEgIHS2HH6rVQJfZYsma5wxgfs
+        eYXzPuLsTyhvAGbwZs7ZDb7bgnqEttM+jEAeY/5p+q3N54B3gBPANta9CJ5LqJ9BaK8x9yZ9twFbkM/B
+        8TPqb1Pvxphxjp8oofLlz6f169frypUryhW2nP8GZcuW1Q8//BDHqf/9338w2Atr1aoV2gwE/wMeP4zL
+        /TUvnuIDJaMidQyN+AFGmLnW0Af0/8AlfoCJ7v+eNffpv0//A/rusY8l+yREs1B8RN9liHYNwlyl/ID+
+        G4x/xNqPTSDvyzyb1y8w9SpXTnlTpIjDK57iAdnN2LkLpJ49NbFu3Uc4f7N0mVSvniaWKBG02yMId2bP
+        1R+Yx7tp08BkzCtn3bbQGRfwvkTbGn0UfPZTP0j/W+B1hNLwBnCKMz+kvMO4BfEm6zdTzgJeZo99lBcB
+        38Eu4xY0+wfnh+4SgYmPpwrUE8bh2aF9e8z2P9S0aZNHuBvSYnGSIYyZM2fW1atX47j2P//7G4Pv37+v
+        MmXKhDZ7nJkBAw0QDwj3xwNh93msMEydjzm2n7GPtJZ9CcJm4j3qBkvufdaYOQEw/gV99nMfUJ5kz0PU
+        D9F/kPbrEHUv5QkIe5m+DyHMTcat8YFlYM9PMMF/li6tAilT/YUvkCRJYk3v3kP964WYGx0VrYJ582rH
+        lGnSihXqU6Hco7mZEYbN/dHmdh31UfIUgRb7nI+5iwXrPGeZkYeoHwQnlzbR+yj3UR5g7ASl191mP7sb
+        3+cQgropIhrzHqmtbgNm5GnaF5lv8/8p5R3an7OvrdkyoARzjFcO4oh58+Y+wjPAFcYuWbJEq1evVv36
+        9XX69Ok47v33//7G4IoVK/5tMzMuXlwZAIQNwP0g4jnRIDMRLToLMa4A1xizn7zDvM+pmxk2RXeAj1hj
+        yb3Nmru0P6T+JubuLHCOuk3bIfbYztgmiLOd+daWC8B1iHGVOdeDfdASSpt+a8xPmbLqaJVqiogzz4ak
+        SZKoQZWqj9otqlfXN5s3K2niRGpUsYLmDBryaMyQOkVKvTF4sL4pWgyfaVMdj/NCvvN94AJC9jZgRu9m
+        vuFVcNgFDobD1C+C48cw6mPaZrZN+D7quxnbw/zX2ecAfScQysvs9SHn3OSeN1hj2ljzbwGn6Z9MmYA1
+        kez5OJ6GpEmTBr74559/1t69e/Xw4cM4Dob+3blzR3/++WdQDxj822+/qU6dOv+2UUiKQgx23QfFlbSj
+        QOBZzPEpkLVJcyTp6PFd4BZI/4OLWDvvgfyXrDFjzRwT7BrlBfrP0e+g5nIcWLJfYd4SzpxJewd7vMGc
+        95jvM24C15hzHbCpDqSfubYa32bPqR+bt1T9p54K8E4BEVZPm6nLrx9Wo6rVNblZjDRshIZWCjE9C/46
+        Q9p0QT0MA2vV1M8I+UWskc+8zDkfUDo4cnxwEZz3g9922jsYswBuBz/Dq4yb+aeAy+DjCHoZweQi1mxn
+        7LU42AMcYI93WWMhchR+gTOusO5DaGlrYV/utoW7CPUo5tvtRHKu+RGPdnAHtPn9998PGPn4v59++gnN
+        nxeY8Agzt2XLlqFLBgvNxDD81fYB4TmpQXo8RLAP/Bo4D1j7Tscx7UOk8wZ9Nr2fgfRdxm6w1mbWFzhO
+        237tKkRwn4loglpI7Ks2GZDcnfQdpc/E/TgOrFVmdhBRg4vLq5x5EbiSLp2OVq2m5KRhCaLjqzPBVZ1K
+        ldUI7d7aqYsjR/Up+5dpntWzl8o8VSCod69eQ5faddCdPHkDIbUJvUT/ReA99jbTLlOepf8YYOIb1730
+        7wH2ItTG91Xmm9EfMPco5UxossFj1K3xnvMy++8GToH/24y/zRqfeZ7SfW8y523mm0ZOywZRpmPMfHjE
+        5KAdoVSpUmnZMuKKf/v3z3/+M9DyiJiYmEcXDkN4cdi/hnxvqC8fWns+QSL9liGTfk6ZQv+g/RZjThlO
+        Mu8QdfukI1zaaYXTBmv2+7RDDDXiRJT03aBuBl/iktZkX+ZE3HqbtZ30HQ3mO8gKWQpr0wfMsQm8xpiZ
+        e4H2WdpvJUqgu2hrFsxzQTS5db36unbwiEoXKqwTvfuIGytrypTKgCAcJIL+fcBgTSCgfDJnTv0xboLe
+        y51TB0mhbCItcNYwE/6UBdcEN66A+zznGKX96ib6FjDnFeqvUbe5vkDd97M2bmSux+x6rO0LEN6F3MMC
+        8A7l2+D/DhDk0Mw1vUK5dbwgB3eEvgUowPowj8xog+vRuCZH1rdu3Ypjb+ifTTjjZmBoouERc8ObsXHY
+        JDeCmV+D3B/ZsuurTh30S4/u+jxPHr0BURwc2c/sYK8dQWnTZNMVFZivc0jxh2YSCNvfOP2wb3NacQ7i
+        vMs6S7MvdpIz7L/2Mncvc/2IYDNmrbKUO7Uw4SwcV2k7rXmPeefjx9cvVWsoR+IkalytumpWqKBuLVqq
+        TOHCOh07VN+PHhXcaWbffvpj2HD9Xq2WOpAbz+jYUb/UqMd6mMu+pznPeLwFmLlvssZRsjXNscJZwHMc
+        9e+nb4vvybhNsIOvA+DvwPAS+H/AvXcxvoG+LYxZk4M2cy3INunB/uxnRTnDvAuse5u5ZwBbRguS8bHQ
+        taK0b3awG4/zH+ddBoLFixcvxrE39A8+/p2hIQb/JSmGZBw6PS5CtrlV/vwaXKyYBhDC/zxyjG7nfUq7
+        oqO0lbnOE7eyfgv7bgEBPxAsBNbhj96jz1GpffF56r6QET/LPEutGfkWFz4M7KT+KnCMM0PEDhHVUv4W
+        623C3gfsu1368peIlB9WrqzMzsFf26fh3bvr69NnVKJAAZ0cNUb7u3YN7jN38BD9Nn6cvm3VSmXy5dMn
+        EybqXq7cgUk2cU1Ym8nD7G2G2RzbklijbCnOMM9Mtv80XtZYR9OOml13FuB1vofz5Dlo5VDmzWO+GbuH
+        PvtiQ2hOSJi8n92Xz7ArO0/9Hc71Y4rxMV4WZu+TBnicR2FwCrV///449prBjwYfY/BjizPD3GMQzP7P
+        +dunlD9lzqINlSoF40NbNte/xozVlRxPIMEOOGAwczbBtJepT6DsHYU5ikqAtoWCLJsjm/PjrLcJMpiY
+        1gCbZRPBexyFub74SeaHJNn+LeSXTWxf/l3OfBscz1CejR+l++Ur6OmMGfX2th1q26ihVk+arJovlNOr
+        aPBBzLRxHtm2PRo8Qne6dtezBZ7WgyFD9UGaVOCBdWDP0+BpV3GQcic47KTPKdEhxo9zjvEO3A9zrH1O
+        kcwYu6dXGX/NWkufzbGZuJk9RtE/gfqLgOc4ura12wnzLRxmooXbe1uobdXMZAu3aWMBC+IcwM+prucG
+        wnx6HBxlO5WKY3B40r9N5vASEO46zPWLk3M1R632nZ8mTKwf6jRWogQJgrkLevTS700a60z8hMGFzKA5
+        zB/P/EkgupdA6wNM1vuUQcpBvy9jiTSjfQH73M3AOuoOQnZx5kHWHOZi9lXHIZqJaMKeps/9DmYsBH46
+        NAOOJkAQ0eBiuXPrp0uXVbnM8+rRspViatbRlHbtpflzlYe4oXmVKvplynTtad9RBQs8pS8Hx+pkivR6
+        nbsEhAQPw3723wodNgE7aO8B9gIHmGecrXl+5AjhFXrwOMD6TbSXs8bg+jZw9KPHatauob0C2EQg+Bqu
+        ZAtuz+7M5trgvP8o88xAa7St1gHarwPe3/1+DLKi2AqWofwb3x6DmTNnunyMwSwIB1aNiZIvE4n+mCuX
+        VKa07pNW3AzSBwcE8fR9oSIaXb58sLZisef0Z6f2OhKVUHNoD2T9UOYs4mKnYJJ9ZpDgwzS/757jrCAo
+        ou8Icw9BFEv1y4z58kvpM6N9cb8cHWf8Tca9x5vMOWlTSNtEDojCmbtY8wbB1XWCpqeIEX49e07jYWDz
+        OvXUq0VrxVSqqF/R4rs1qmkdkfXv48ZrVK3aypolq+6NG6u3M2YNIuAQk20prFmhmGIzpRkVpEPg7hzY
+        wZQF6wh1M9pWxebYzLFrWQYsob6CcQusLZqtkqPoXYkT691yz+uLNm109onc2giTt7K39/ccp1EhAfbe
+        4MPaI7S9/17aFnK7Egem7mtAGWbqfwP+73EmR2owWut88zb2/H7DplpNECJM3c/lyulO2gw6Hx2pL2H8
+        mJIlg3ULB/TXTy1a6bU0afQSUjkNJqwErGGhSDNk2vwgbz9rM2Oz7HTDeWVgxqibKMspV9JeD9hcm8GW
+        3le55E7A5iwwWezn/a25oRwT/0leuLd2TUVDML1+QA+mzlCralU1vk9/pU+bVt8ueFE/l6+oB+CtBg3U
+        rnixAP+PFr6oT4kpjMvhgJghnE1MM91MdmzhoHEPeFuLfZ7BQZaFzS9v/oBgbTazLZyrAAvrEmAdY0Gu
+        zNprOXJrTcXK2jZunDRxgi4T0+xJmEgb2ccpoiNu+31biuAcSvt0WxfX7eedjp6lfpDYxgFuX9aEePgY
+        sJbSldCgX6UGBP7WLyzknalS63zjRsFYS6LS9+fO0y+xQ/QvtELNmmkUEavHLm3coPuzZ+v+4MG63b6D
+        PixRRufSZdBhgh4TyhLnaNE+zj7LDD4Fgr6sEQ60BLCWGKy9NmUO1BywWQPMcGtS4NcorWlmvE2ac8pd
+        tG9ibgcWLx7gdGU+zOzVUxtHjNTmOfODviFojNau1sMJ46V+/RRTuEjQP7FbN/3Wq69OkkKZqdZQC5eZ
+        6gcNg5njqD4sTNZu42HL4djDeLxO3cIX8skh1+H0xgxejq91fGLN/PjpZ9SJyN6vagOaNNX3U6fr27IV
+        dDpR0pCbgmnbUZDdZAUHULIDKM6JzJl0NnNWnUmdUrsTxtfLCW0ZnWbZRcBo6p2px6cessSPM5hNzeQh
+        UfGDpzIz9xr9txIn1deNmgVECIA5TSpX0dJuPbWMAKUUkucnyyyE50VBui1554QOnfR6//56SEBzGUl1
+        UGSpPsm840jxMfaxHzFY8kwYM9jMNJM3AGsBM9R+bxtzNoC4o3EHbVtYbxNorfdDg5lrZnjuhbx51Yuc
+        17jOss/t0VPjSpRUwkSJCB5DQjxj0CAtjB2sP3buUps4F5OE8esI6B20aneC+EFQZcZsDM4LaZRfo8zQ
+        4Dz6jYNxt4Duch/wCnVnDvtZY0bauhivlcAKwMK7B0ZfJbBrRHoZpmuZwoV0B2vzExbyRMIEOgDjP8j7
+        pL4hSPyuV3d91ruvLnfvpsu9e+mn4UP1Xfv2ejlvTm0l5jBtnaPvR6AcI3SjHtr3kUaHGDcaf+vHfL/3
+        XgH8uHCJ1OjXkqXVrlCh8OQAovDFkQRMrqdKnjwIVArlf0q5s+dQTvxfBszhlLbt9AM56BEjzF42YTZt
+        fqy3CbOUu3RkajNoIpoAGznbz5VmurV3M/52Nf3zqC9gnhlvYpsBNoEr2M8BjD/PvZkxk+bEafCE+g31
+        c7Vq+uXfPnumJshqWrOmCpAWpUQ7wv2Fn3hCXw0coNexWhvYy+esAYfVwAb2D3Ci37FCoN3Ud1PfR3+g
+        9caJfRYF6yy0IZdirX2Zee530LWBOe/kzafexDCP41Ug95PS0iV6iCarWQvdgpHty5RRPjQ3KxqcDrzT
+        pkqpJ2kPj2mqH2bM0Jkiz+nV6ITEMlGBwvj9wXQZCIRjqYhIEGhDCuOgx3mgnw39iOAE39JxJllyfVmv
+        nnKmTv03hJInTaKnc+dSrTKl9CnS/9vosfp18hStiss1K5csgfT10hsIQOCnEB6/bh1nf8MbgLXbhDEB
+        TRRLuoMMM9DaYEK/DINXMr6QukvPNcEW054FLAVPvyRtYu9diRLqAgw+hVt52KixTqVLowcQqU6O7EpK
+        xJ+K4KZwlsz6bNYclcv592+tWdOk1sddu2hfqhQITigCXgDMAZcFnPEy+JupodcoGA1YCK3JZrK1Zxul
+        he4lwIR2quRxm/r1mNyNlL7ToUwZNI84IJJ7PI5Dm1o1pFe2awyaG+5LiMtMgKmOBIfH57bAZf48c7bO
+        5s2vXShcOIIP3BrQgrMiaUdUwk++yWIz1O+ufopz+uLgaA8T96HFd/3U17evXniumLKhJWlTJNfBcRO1
+        beRIkKqtm/i73TB2A9pyct589WzeQpMaNtT92rV1DPN3mH3NTPtcR5nWXAcKNnUm5grAGvMKbRPPpnEF
+        CFvqlwLWIpvodfQ51XD/VPqcV1qzl9Nv4bBp35k4oU6kTqPDSZPpOD71hBlXophOkbdfrFtPnwO3ixbV
+        jeo1VBmLEx/GF6Tcgi/8+Pmy2h4/OnAJZtQi9psJY6ZBm8UIkNO/kF8OlSamNduMNIOt2Q6U7G9XscbM
+        NLG3cX/fzS9YFvaDRPtvV6yo1Ajk40xLCq1qYKZdL1+woPJnz6p+bdpqS/fuml2lqopkyfK3+QuIHe5x
+        n1exvv4xgjXZwZjzbgeENcAnwrmec63ww4GfAsOvM0bYvyG6+2wR9X7+eaVNnUrdYlroq23bpeWrtKJn
+        H8Vj42Qgljp5CqVjPCEE69Oiqf5Ao89myBiY5nCU6aDIYIm3NqwFTMjgqY8y6KP0y9dCNHcpKZaj8ZfB
+        aTWwBnCUPYsLTGTOFGA+sJT1y+l7FVN2pVBBXcYE3gVfDR2iB/Xr6jhMPp0xg35r1ljq2lnXni2qNzJl
+        1Pto0ZV6DfQRqdVF3MweCG6GmHEWOLuGlT6TttO3tdYQGBeOqM1cB3423Tsp7bsthCuZ4/RoNXdw9Bz8
+        dIexbYDd0S7c23X8bvdn/u76DKXA40yP3vqiSzd1Bb8qvse8efquclWd7tHrb3O39emrm6VLaSdZg4Ms
+        P86cgQ7+fGne7ef8CPtC53JOYZyfnmHQJtSBgoMEpw0fZ8+pbZUrKxnM82+Flo8eqY2jRihvrhyqVbGS
+        9q1co91LlqoQQY4Driz4is/at9PRJEkfpTnBOzV7WkMdKToyNtOsre57hTEHUSaMAxJD+GHAjDWhTeQV
+        zLM2zeBC/qQ4j/oC+tYkTqa7TZrodOwgfT1rlj6bOUfZM2fQ9Tmzdbd0OV3N95TmVa2i7nXq6u70GXrQ
+        qpWukBqdzJpNuzHdZpjdg5kbZvBKSmvicuq2EisCYcPUApsBvy07TnAOu45yIfNfRHttogMtps/gNWay
+        g0g/59r97E6URN82bKbMj8UBiVCUvQMH6z7B3/tE2SNLlw76f1+9TiKXX4nbiRc/SkWJF7a2bqMfm8To
+        eIqUge93HGCr69TTFsPuwG8EEQEzGXR473TGYHMa0rxQIn2O6PonfFt/DvWByfC/C8aO1dDOXZUja2Z1
+        bNxY727bpvxZs2pXr956BfN3vVgJHWCdzZcjYxPL+a21IjC37LOOvo0QzabPfYG2AC/Rb6L6lxCe7+e9
+        OewzHzAzpzE+ERhP/1Ta082cHDl0smOHAL88OXPq4vZXg4/4rdHOP4YN1TsEVa9Xrx6MF3jySU1u215v
+        DB6ib7v30JGMGQPiB8C4fbq1dXlgRTDVcWfb59snz2FsLgx0+mP3soa25y8Gpnk+Qrce6+N+C6zdh8EC
+        a6vl4M1W6a0sWXWEzCMunVFCAtINsbESqZ0Gxqp33A8wXps9RzcXLVJZspYhzZrrU7KDy2j/4cRJiOJD
+        L2G2Jn5r8NctB6zGy2VE+LHBvsERrfNWQ/CCwgS/6rwBE95Nklj/xK+mw7f50MY1aqlz4xhVK11G3x1/
+        Q7P79tdyTMhXTWN0DHO4J37CQCusqUsorXETWTcnMF+h/jBjV9FvqV8MLIRwiznbxLAUmsDTaZuJ08Fj
+        EvXR9A0HhgFjmWdTfeypZzQMH2rcDD3btlFM7VpEkZH6bsUyXSv9vE4XKayNxAzhOSmSJdWCtq31Jfe6
+        VryorhcvpiOZMhGw4RrY00I1lXlTqU8H53kwfBp4jKNvLHjMZHwuY2b+IvqDRw3mLaS+BibbH3sfuxD/
+        +M6xwzzWzueOyyjXR0fp4nNF1ebppwN87N6qlXlerUhFqxUpoieyZlG3lq20fvosvTRuQpClfD93vo7k
+        zaMlBFbe38y1dXRg6ocQv4LZIjojcQwQ4e+15ryZGTalzk+twX4qs/n2mDX9KhHo8bpIHH1TB8eqPCYu
+        J0gMQBvqk0NOJdD6rmtP7SJyDvwl6x35zuUMM2ZyYL7M3CgQCGnnS+wbZuwCYDbtpTDFDF5Haa32nIXs
+        4TETdwR7DWe9mTwVgbEZPJIps47EtHrEvBqYuTrlKwT12f376cf5C/QhAclVfHKtfPkfzRuDK3m4bIUO
+        9B+oN0eN1PcEk68SOyxlT0fRY5njL0GjOGsSZ06iNA7uG8bZ/ogwlfs4GLPwWtuXAWu4S0BkwO7G3399
+        R8cMc1g7D7DL2Zo8ia5VrqTOhZ5RnvQZ1BwBrIW1HEHAOgVznRKFWjV1qrbB2GKFn5XmztWhdBkDC2eL
+        YUXZyr5+Fwi/sDm694OQz47wVwyDmWh/6dzOLzb2v9Zsq7zHzOgjXOIaZnosvqFk/nyqB1PzYhpHxLTU
+        czlyUs+ue6RGu0ipLKEOiKyN89lzcWDunNOasTZdZi6XpnQk7AvPpT2f0pJuphtMsNCckBUYR98I2mGC
+        m/E26/sypNedfv2D/C9BgoRaMn6C0iBoZuLKMWNUGKk/MGKEfiP6nwuj/T01Y7p0unngoKqUCOXOhgsT
+        xuutAk8H78gvApPZfwjlQM4axPhwwEwdQRkLPTpTrw9j+xI42XVYe211gqietTbTrgcazBrvac2fQXsp
+        a1axxy5ilRvktFdatVOr6tWkt07pKAz1x5x8uJa6xD91K1RUFNHy7fnzglRwC9mP00XHDQ7yHFj54SXQ
+        YMDuxgoUEXyCA8F9SIG57w/SBn/dCR4mmOTvm8E3TszCsTRp9U3jJvp8xQpd3vmaqr9QVr/u269v8cnX
+        mjbV6Wef1Sp871IuY1/qS5lRvqAl237Lv1Ny6Tn+/ZUZ7IsHzKT/Rc5325LujxezKWfQnkR9JGutwWOZ
+        Y3NpE7mUy16HACOrVCYKfVqXVqzWpN59Qxraqat+XrZSFfLkDX4zfWH5cm0aNpx6VMDg5gRdObBCnpvR
+        QoIpfC17Ns5H2DhzIkJpgfIHlL6AmW3LMQKI5fwuELYy9RbgNQ6Yy3xrf+hd3QFhSEBNB6ddvtsU2iOp
+        T6W+CrBP3sgdLpevpP4NG+no8hXKSEYyuk8fFYv7SVEYmlcop0sxMZoJ819EOLay3j+KcBaym30Ocr7f
+        FvwFzAoUcZBK+E3XIbx/UGapCL2xmskRwdPZZTTgXo3aetCpi64NGaol/fvry7371ZCEe1bsQH2KZH1B
+        pHcczd5CHrqGXG8tEeL6FKm0MkkyLUY4zDSnQL6omW9zbW212XIg5ceLgAicOZe6wR+3zcTpWIBxtEcg
+        9aNZZ1M5k9JMWIMZuwteVYpgwpat0j9IK8IEWTJitP61catGIZRu92jZQhMxw663rFpVX+3cpfFduwXt
+        Z558QreJIxYmT0YAFxFYiAlxDB7MeX2Z499HmbljgZH094KJzZnbkrF+MHgM+M2kbwFrQ8Iaup8ZbQF3
+        fTowCoWaGHd/W6BNxDj3iex19h2VfOYZdWnaTAdWrtJrLy3T5AGDyAgyKzk0HR7TTJPKvaCqCGsh9nBc
+        Yub6QcX+OPgOTWnT7X0jwo/mZq4fHpwi+EXGDPaj+24k/WaJEnqrfXsNrlFDdci7/LVm1YRJuvfKDpXC
+        L9w6dBAT+IQ2DhigS0OH6t6QIXoIUp906aIrnbvo867ddbhwEa1MlDiQbmuuTbQZau30j8MXBP0wGKQX
+        gJyZGjDXc4DJMHg05TDmjoaAfuSYTtvavx6XsPaFF7Ssbz/9uXCJSuQIvVI1qlQlCFxiatZU7xatVLdK
+        Fd08dERFiUarPP+CDixcpDMLFmlci5YaQYC2oFoNHStbTlMg3jDWW1tHcNZYYAwwnHYs5w4HZwvABOYE
+        LgOcBjHWn3ZvykEBjmZ0iKF2P/bnDrb81w42z9beqQj9krQoA/jvTJ8ezWyutmjwhlmzdXTVOuXOlk2p
+        UqRQCdziptnzdHvrbi3q3kVlUqVQAfbIDq2qWKDYx9+cbaqdIpmHZvAyBC7CGmpGWgJeYZIds0Pu8AvM
+        UQ7/pF17JSckN9EMSYk+J/bpp88PHw1+q3Vz92vajp+LgvHlihZTQwKcagRg+ZC6bGnSqA1BxLcvztf7
+        L5TTaghu/2yTPZczHCHPAElLvLXXEabNsYMnS7rBptma05s5vakPoT6BOY6ePXcuPvdghfL6FrcRi+Qb
+        x5RJ8WvTZmgQpjvAGQ1JBt67li1XjkwZdGHjFqWiPalPX30+drz2IYBrsmTRHO7pHypYSweDzzDAbQuY
+        s4CJ1MdTmrkOwBwL2BcPBrfB0G8g0Is5fQOhMDOjSKmwNMyzEPuOwZ2A9Zmz6E73nnowerRutW2ru/0H
+        KGPKlEqdKqXSpkqtSkTU7Ro20aQevZWC1LQcyrR2yAgVxGJl47xM7J+FPZ+GVv7zl7mR0cEbg/Nzv+mv
+        g64R9rdWbUdeZq7fTDcljNauhAkDf/uAqG5hs6aPmGvIkS2r5sQOVab06ZQAaW9Vu7a0+RXFVqwUev98
+        NBcJiqu/UPQ5/T5+rLaypwMvS7IDKmvpHJALS7s1dhLgNMS5rk2hA5tu1DvT34W6tdg+eDiSO5TEf17W
+        bHqPqHN++7/y4MszZuhC5476ZMoUpcC0hfGwH95MnnltyUtB+2UIfBI3M4m0zgwZwzlmWgjw+fT5rInc
+        a3IcbmbwcIhq7bUA2D8PCErjivZSjg/WhNI7585BDk/dVmo+9x3N+t2lSqkZKdJzTxfQ4l79dGXtOs0d
+        NFhP5c6tnZjmsijJ4nHj9en+/Zo3fJhmMbZ34UJVKVRIWePHVzrOzMDeGYFMQCn2XABTtyGMTpH82TXC
+        /jb4akPp15vdaVLpw3Ll9HXr1rrTo4fWkk9mS5f2EYH8E80y+Z/SLVKLBN6AvkgO85eQy3XqaWzJkkoY
+        /6+/MDCUYv5cBOWjJk3wySkwzQRenGl/bBPtPNMPBH5AcKRsIjuQMpGd61p7HcU6qBnGnBFI6sRUabSs
+        UGG9WquWTuAKWpUpFZg0n9e3TVtp12va06u35jE2FDfhRw+P1YZof8x7UQubNtGTzP946HAtxDw6nw6Z
+        4ngBg8IQYrAZhk9mzJbDGu3+IUB/6gMDgMGANd/PqNMgsu9i9+KvYBZe++NFnOFI23dejM8fWS70yTIM
+        6dKkxn2UDTKU0gULqWPFCiqPT45GkF8A986Y8bFkKk9nzKA0zE8fx+T01PNi/Uyj9YBf29ZwdoSTZTPX
+        3F6LZB1/4kmdxyetRmun1KuvfCT+fmnxW/OQOrV1fcgwXWzeUlcbNNTcOPNXjLzycyK+ZanTaTfSuLdO
+        HeXPkCEYi0Qg9nbvoXdKliEYSkIuGDJTBufHUygdVToituly4GHNMWPt7wZiUfqwTwgi1YO+HsQFc5Hi
+        LZ06aHTD+mpRprROEvhNbdX2EaEm9RsQfBRxPSP55Yb589WmfkPtHRarf3Trrtas90PCvdETNAPmO2Cy
+        n7VwjQbcNhMNZrS124wNQahvKPMtfMatG2VXyv7BWqdzvlsoHXI24AAznB04W3DsMCVRQu2oVE15iObD
+        eBvS49b6NGmmj0aNlRDGPw8d0o75LwY/EPB475gWKpQ9u1KxRzr2z0hfWs7IDG2rRxF8QrPV4OBXswhr
+        rd+D1wPBuyk+6Hie3Lr8bHG9V/J53SBnvEYEeg8f8SdE/HrsOF1GqxfB+I1Fimhno4Z6s2VLrcidK/iB
+        3UyEZC1jl8jn1hDUbCQNuVK9hlYlThyYKTM1HB17rs2YiWbNcN2EMXPt03rS1x3Eu9Pfmb4OQGv6/dvg
+        funSaEm5stqOMB2pVUd7iz+vFTX/+vOb+KRqHTk7S9qQ9RnataumwvSvZ87WjY6dVBimp8HfnSU3Xpgr
+        R+AGHESFLcdIA32jDNTDGj0mrnRkbfMcC/Sl7r/17cDcnoDTqX702Vxb6/3E6TuHzHRcndIWazF47K1e
+        Wz2KldTxF1/UrsVLVYps4OCIUfqqdRuNKF1SaZIlV51KFXV04ya9TeywdcJkFc3xhFLByJTs4780Sc2e
+        adivGO2R9Ds6t4WMMGMNfjEKpSShH4z5JcnJ/jwCp+Uk4pcqltfapo2VjVxx/5BYbS1eUrHRMCNJIsUm
+        ShTkgDY7QRIPLCCY2oTp2+FXIfz5PBjj/mkgYbA/G0/pfNBEs58zc51j2pc5JenJeK+gjKdOjLWmP4a+
+        lkALM5rcsW38BGrHhfz3yAvLlFFMwYJqVqx48GH/l8PH1Dju+bJT9eq6NmGirrZup7fJIzMRqNjdrOrZ
+        Q8dq1dQ47jCMcxw9u/SPBg1hLTbDLXjuC5Uh5hrX/kA/oA/g30YNAOyXbcItuLPA1374rwedkIAvIjhc
+        nDS5XkqTXrdbtNVmsgDjGkOQ+glW7yVofbx8Oa1o2UppCLw8VoP7bBwySiObxCh9ssRKy95540UrJ3um
+        APJBl77QYy78mMFZEf6Guo5Ji+lwamIJW0bbYJ9hZHbkyKm3IEz6uJehYRDocvtOGpc0sQa7zabOGUNv
+        tnHRLe3Z7BlKg8x4TDBjlmhrhTXGzB3FHPutsMaYKA5Y+gHWhN5AN3xLG9Y3Zawh8xqyRz2gDmvr0vav
+        Cpt4DsI2PU8enWvfTi1Lldb7W7cqD2b4dSL8N5u10JYCBbXxybzaWr+BkmEeEyCE1YkZflq+UpexQpsL
+        F9IUBCMUFWNFODPAEwhyYcBRfA9KM9Pm2cy0MFpj7Y97uw3OZrBpY233C9cM8LM/DjE6Qi/hrq7XrqWv
+        iHP2PFOIKLq1EiKwUQnj6/KYCVqVN69G0X4pS2adb9tOLcAzCrxM/3SY8FdJRfPgBjOxZzH662ANrcU5
+        oEk76rMDgMF+DPdTmhNxh/EG+4qQKQ39Hc2J0mVUr8BfLyq5smXXdfKyQ7VqaDK+eTSRm8N+a2XgT5lj
+        ZprJLqe5n7pTDDMylvlB4ML+gS8zsCaWcRM1IBQEMXP9UtSc8Xqsr029JvUalDWY4w/aNZhTn7VNGG9G
+        uyPBzctlSqobKdmambNUsWRp/Ygfm50xi0YlSqp9laqqf7nQG3Xt8hWUHOtUgLhjUe9e+njmHF12LJE3
+        HxF6dJCOGczcgMkQrafPod2CdlfaTonM9D7g4dIm2rmwNTqkxSGNj4Xww5nvGGOWaYoZnla5qrrWrauH
+        kybphz69lY+UtFONmrrcu49W5cunDcVL6Bz5+3sdOupCj57Kny69spO5DKpaVacaNVdFFKwa+1bnzNYR
+        0QRZkUqBD44xrQE/BEWEftYZkqqwhBkc3lvz5mPGDrxQXrlS//0PrJ/MkV2nxo/XuyAwm5zN/nMq681M
+        BxbWVKc51mYz3nljOCr2w8A4mGSwzxvGxW0WbZ6HwiBHpdaKLpRNGa9Ff3XqYajmdhxYk63RvlQryrb4
+        3teaNFZ10o8aBIGpwfuThYu16OlCWo+gbieVCkf5x0ihhjz2dSmS4K1nvXq6NWacpmfNqiEQzEJnX2qc
+        bWmssa2oN6L0z2Lse3vFgRnbm7n2yQMpfY8BcXVrteMI/yhuGOe/hcvIiXJEwaBe9erqxxcXSDPn6f6K
+        lToeO0SnyYkPxg5T49Kl9FL3bvpmxkx9gqD+a/duafVa3ejQSZOy5VIH7tuW/dtAw/aYaj+bFmfPTuDu
+        vzGO8HOa/wrBf2Lih3WbE0ezZpZhOj74leJlVIwLhwkRhiykT8fHjdUJNHkG/sSpjn2wmew81g8BkwFr
+        t5k7hP2d5oSDllHMG814yAeH88rQo4E1oD1I12efMDOtsdbgaoxXY52ZXZ+2GWwTbWHoSFC1jhQvOUHd
+        osHDlDg6via2b68vp07Twf79lYJ+4z6jVSvtwNX49SoJfvzxey3q3l3rK1dSX9b2Y18zKqzNtiwO8trR
+        1x4i2sKEtDgklPbBfrIcBC6DGAsYzDwzuTPjrSk7JiAXr1RBGZKEcDFULPqcTsxdoBwEjwkY91t05rjo
+        OiN0fn3WbNV6rqjyZcmiIuTJY5s313v9B6pPylRqy5mNoEkTzu3Iua7XpW7FiZhJx2QmWHssrU7QrX3O
+        C/3VxExYkjuP+hK4hJF5HIrky6NPp87QnueKaxraboZOjtvTn9H8AuSnvTCRhnKw/ZoZ6Q8HoRwz9JXI
+        TA9MOESwT2sN1GFtLdrW2jqsM8NrUzfDazJuqOV5jBm6Zc+pE+MnqzH542/HT+rGhk26e/CI1saOCH68
+        lto/VmjTWmtqVFZnYopphQqqcYH8SgTu8THLvlNM5co636evBqNh3Wg7ivdDi0unaUF0T93v0K73ARwz
+        OHYI+WXqjJm5fr4M+mlbEFpQtoDh0ws9o0Zxf6weBn892gKeZ+bOVSpSN/91f/D3wLi0DKlSqRqRdqbH
+        /mj9gykTNSRzJrTXb+HxguDTzHbbbq2PGWxG+F3XqYp9jJnqN19HiDZHE7Hzy5GYXfiGkln+U4sN9co/
+        r+8mTdHyTBnRVpvlsLm2jyWPpW0Jd7TpqNPM9nut81z7t8D8cRkLmfNPa3kP9o2hXRUoybhNjwMs+1sz
+        8pEPprRW10JYanFOCwgxvlIlTceEDSaX71q9plqVr6hcadOoSfHiWlyvoTZVrKweSRKoLYTrgPbOK1pE
+        i/FrU2KaqzkpXboUKXQC8zjnyTxBbmsmGzqzv02ytbZ7HI42zc6DbYJ9PzPY2mv/a+b2iwNrsPN4B4V1
+        bAUICNfVrqu8GTM9omO2jBn0y7792jNqlJ7JlVOL8b2ZEMJsZCJf7cQ0n7ukSs8VU5IkSZQdf3yqXz/1
+        wm+HmBsGp5HONKwgmOgJmGAn7v75y1i0zX7GBHaAE0tOfKJBA90lCv2cQ2/ExqpK/r9/vgrDOnLMS40b
+        a1fBp/V6ocJ6OUt2zUmUJJBaf20xcRwNB2bMAEMciVr6Le1h5g+m30FWG+Y2ph2DXzETmxNENKdswFoz
+        uJaBPesC9QBrdl33cZ9WRMK9n8qvocWLahIB10wYPKdCec0tUVKjEdIeuBMzrBNndECwOuJ7h6fPqDX1
+        6qtBxUpaMm6C5sc007ynCjxicJCLew04GELPpvbBIc10Omf/63sEmku/GWvmm5Y23b6X07wq9NWj7JEu
+        o+bUqa8kCUMuImWK5BrWsaOSwvxDxAcHYHAHoudWCOXGiVNU3T/iZ+7srl10snNnzc6fT625bwz7W2Nb
+        sH+Y0Q04vyp3i3D+au31640DoLCZ6ceEZQULaW7dBoomKBiENtxdvlw/bNmqmKpVgt9lGbIgdYnJc18a
+        OVL/Wr9RNydN1ZVp03Vv7ATtKVNRHaLjwShMCNATcIrRPQ56mDiANSEUnIQCFBPMhO2HRTHzrTEtYbSJ
+        YtNsxjp6DhjMPDPdmh0wnbVB4MW+jdDQBtyvLhdtFAURyNstOB3i9jcETGPPzoxtqFxRZbJm09ievXR5
+        whRSrnzqRtrSiT06MqcTc112BVy2Z58O4OT17vNejqKNvwXXYA23IPily3m9g6wY2r6L44ehT+TRRKxj
+        ougEKv5MQZ3f+ZqqlS2Pz52uecQ2S5s2U02EbmDHTqqN5UmZLIneJUWalys3Z5JhsFdTymZx+wbAvt7b
+        wVaE/d4YBkcCZrClzSbVgcG2ChWUJ3WaR1qakfyrfcP6unngsN7duUdnXtmu28dOqm29BuqPtBUhtLe/
+        8NyWlSrqROMm6hcVhV+IIDdzZGcNMEFN2NCvIbpSdgWpgOEBhATB+aTfny31HSltnmvSXxWozj5mcJAi
+        cYlmkdFqHY9oEiHoSFTZhXb3yPjsEx+CRgfndGCecWjH/oaAUextk+vxLgjA9Fy51L1oUWXKkF43Fr+k
+        i0OGaQEa1AHi27d1YJ7XdeFcl4HvAxdrTpug7cAwxFDfpyd138ftEA3I1elz3Wa0KfUY9l5ZrpKeJXiq
+        WbGimteuo1KFiqhd43raN3ig9nbsorKkSx0JCBtWraa8WbLp4/6DNCZRouBlrzH7NwLCpaN7g98GysaL
+        0H8B6cADuXwNMyUAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="gig" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAACxEAAAsRAX9kX5EAAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQflCwIHKzACYgJL
+        AAAcA0lEQVR4XpXcVbAmxbIF4B93dxucwd3d3d3d3d3d3R0Gd3cncJfAecBeeIRAIgjoM1/OXvvU3gyc
+        eyciT3dXV1dlrpWZlVX/5vS6//HvzTff7Gaeeeau1+t1o4wySl3/P+Kbscceuxs6dGi3++67dyeeeGJ3
+        0kkn1fW4447rjjrqqO6ggw7q9t9//7oeeeSR3THHHNMde+yx/XL00Ud3hx12WHfAAQd0++23X3fIIYfU
+        d20/96eeemp36aWXdldddVXd67/PPvvU9eCDD67vXA899ND6nhxxxBH9ot34Bx54YOm600471f3OO+/c
+        bbHFFt2ee+5Z7bvuumu3yy671DX3+qRtt91267fH3K7GNveOO+7YzT777IUJfFZbbbXu3Xff7b7//vtu
+        00037cYcc8x+3Foc55lnnu6dd97p/vzzzz5m/m///pXgc889928TeW6lfTdYxh133G6JJZYog48//vgi
+        lLgnSAEsAACJAGQiLH3dIwI4QCOcIKR659sLLrigu/fee6sNqI8++mh35plnFsH6XHbZZUX+CSecUGN4
+        d/nll5cjGI8DmR+J22+/fRGBTGPvsMMO3UYbbVSEk+22267bdtttqz1tJE6x5ZZbVn+EEWPuu+++3d57
+        7122Hn744TXHIoss0o0zzjiF1YYbbtg99NBDZYPvRx111L/hSej5+++/9zH0v//9I8E8cvDg/0Zs2+Z+
+        0UUX7fbaa68yhvdSDHmt5B1gGY4MgLZ9EIYABEfaCDTuKaec0t16663dTDPN1I0xxhilw9Zbb93dd999
+        5SR33HFHZY0bbrihAOQcV155ZUX6888/X/fGMj8SEvV0EdGIRJQxN99887oX0XGERDKCQ7J+a621Vrfu
+        uuvWO+NwLGPGZsL5YUXnscYaqzLdsGHDuk8++aTsCaatLLPMMt1PP/3Ux9S///sbwT6kmIFaQiPtRHnO
+        u9FGG62bfvrpy0CAITDpD1khJcTkvXsEcypOAQggA4UAPdELeMAgPd9ef/313bTTTjtAF8+vvPJK98gj
+        j3R77LFHv84vv/xyd9ttt1UEekbW448/Xk7AmURa0jSdzEcnRCLadyJYOvacKPZM5zghXY29+uqrdxtv
+        vHG3zTbbVCTHBqIfW9jBdoSOPvropZf5krajO5lsssm68ccfv5tmmmm6Tz/9tI+1f/43gOAff/yxW2qp
+        pWqgkJf7VtIujaTNhBwjSidqE6URz8gJQdqAiURAiQoAJg0CRnsiC0DGz7hIuOaaa8qxohexPJjDeJ4B
+        N9dcc1XUWss222yz/r5TTz11d84553T3339/6RyHopcrB0FkdHONbkRbdPRN7NG+ySabVLoW0b5DpIhG
+        dpwoWYmst9563XTTTVd6DRkypJae6EngbGnh1Ouvv3736quv9rE38n8DCF5xxRUHDNaSOliyRojaVVZZ
+        pVIN7ydAoTgiIokGwjBGISwG+z4EAwMw0iCQ4vmJrng/QFzPOOOMKtradWu88cbrz0Rkgw026N56660i
+        fs0116z+eUcmnnji7uqrr+4uvPDCIhRBscc9HeiI6K222qrEWhmht0hnG/18o40DpH+in81sj8OS2OQq
+        G8AUtiNbi9nGEX/99dfKUD///HMfgyP+ffvtt91ff/1V90XwH3/80a2zzjoDBkFiriMTE/OmrC+UAgBw
+        WgIoQrTpF9ACmGuMNZbIoovUhmCpCnC+BYRrSOY0iYDTTz+9Uq/1id4TTDBBd8kll1SaNp5vnn766f7U
+        TPcpppii314CfNnAfIROiCLu6ep7Dkg34p4gGflJ1fQSjebWz/odMYa12rhshllwce+de/rILm2mjNDX
+        MvThhx8Wke2/X375pSJfCu8hl3f5YGSDjOxZ5bfyyitXiiWUEn2JRAYigzcjWQQDmEH6hjRGBEDPwOHx
+        1p0UMkAznrGIb0J2RBvwOZJiSpQqtgDJUdZee+1ygAcffHDAmqYuWGihhereXFdccUUVbHQ0XqQlm410
+        An5SdIgzRojW1zVrcCJdH88wT1AkMIg2Ea7NvMheeumly6aWi/Ah81h2Bv/77bffCo8e74vBkXw8sgEn
+        n3zyUv6ss87qTj755CKPQoxxZTjxjHRCWd+EUIonGvMMyFSgvk8KNM7g/hHjEcAEKFuhSSedtJt77rmL
+        zDfeeKO2I9atp556qqKW2DY99thj9Y19/nPPPVdrtvmAbE5zBHS6hfC0cVRp2HJiOZB9EK1NP/r6znvv
+        Eu0cjpjLezq4cp4ESYgm2nzfZpyWE/WFzPX111/30TvinxQ+/P1/CW3v2yuRJoAmYs8777xKhw888EB3
+        2mmnlRKMQgoPbSWeS2lRwOikawAyLNIaZjxgiRDPQA24ASQkGxchRPHBCW1PVl111QLRNkQ7Qtlkm4Ts
+        m266qdZjnn7jjTfW98CkQyvmdzUvSR/tsgTw2Zj0y0E5Kn3pCBckczj98qxfO76r8WOjeYzDkbyn3/zz
+        z19rczgJT2TKKafs3nvvvT56R/zrtUS2hOYjYn/mxMVaJ2KtbRSk0BNPPFGRzLh4qStjXFWQvNWVgolE
+        RgwGLs/IjXPEuLxjdIAAXlKnsV2toRNNNFH30ksvVUr//PPPuwUWWKD2wOeff37ZI40/++yztXdecMEF
+        K3U78IgDZQ56hDCOknm9j6QfR9TPvavv3NN/jTXWqAjjTHCDVSR9Ypt7c9CDcGQkm8d79hpHym45ithC
+        2fbl3/C2ES/+ieAJJ5ywJkh1qHhQtSLae0o888wztZ5ROGkIwUhdaaWVusUXX7wUT0qlNIW1uQYk3yMV
+        CMZIujQ/8RzxjXECAuNdpWgpV4RykosuuqjqhYsvvriEznTw/pZbbunmm2++IpjzGhO4mRNR9DFOCKQz
+        iU6+cdWW/rGDDe5hsfzyyxcWnN074yXLuTeGeTN+bNMGGzbrw04B4n6SSSbp56kVVbYlqQhuiW07eba3
+        RKo9JwCQKwIVTiJCZOvrtOj2228vpRiEIF5r2wVcBoiuSBRvI0DailOkCElEMK4FtjWa6BeQbHMsJd99
+        912Bqs0Wif6vvfZaVc+qWydY6gh9nXiJXmMESJL0yx5E0Il9bXTql2u+YYc5iPs4PD0cSdq/ajOG8Y3N
+        htjRkslWY8Y+Ilul9phhhhkG8NbK2WefPZDgVhxuG0Sna6+9ttIasg2OSGU4hXzrcMQhAUMR63nZZZet
+        LQIFk34TZZ4TKYw0Dq9GLOOtn4hmOOOM63viG0b6Lt8mYowpYmeZZZbum2++qaxjHP3pInUprjiqosp4
+        DhUefvjh6pvIArCx3dMBOSFKnxBtbv3o55tc9ckWiT3syvchU7V+88031/rvXZY3Egcixos+xjcve5DL
+        KbXNOeecA4gdJH9Pz8iRBkTuddddV4cCL774Yh0EOM4zsOLKZL5DvggGPkCt17w1RjPIlWIh2tV7xhiH
+        kfF632ZrEe91HwJawz37nsgsfsRQhHz55ZeVho3FDoXXCy+8UDZI1fTNQQjiOXILbOs4SAk5ITeSbwaT
+        ra+5OSui4WIsfWDIoTgbnejse5kiZHsONpnHuO6NwZnhmHn9qMOWVvp4/S/BgLHnEqlSsYo5R2WUVTWr
+        RB2G33XXXWWMd4B0iCCKpW7kG4NCFEAs8hOFST0Uo3AbJQQYUlmMRXYbBUBGbMQz8BR7QKKTqKQv/ZGq
+        jWOqMumLVMuHdo6hv+xEn4wXUonngE3aefNM2MTeODb9Ecxxjee9gi6FEjzUMMgWlbHfnMbzHpkCTuZR
+        ZGlnp3YZMXMtvPDC/RV2ZLh9AyM35ErPCimE6ZN+lPWTG1GdKtWdtijfGUMJVTay/aiAZApQNN4NAMJY
+        yrYEIxK5rtqB4p7RRJ8W1ICsr0JPxNBV6nOMp5/fXvuMrWiRHv1aA3RtDm4QLL1HH7a0EaXNXMS9OfU1
+        fnTQjySqM5Y0TYylr4yYEzdin05XBxacH06iHPb33HNP/RAik3oWYJ7hZ2x9kWxOY+eXqdg7XEY8KIh4
+        B2LbfaWf0pzG9HUu4SXEvS2JQoXMOOOMdUBuQ45o2xCK8C4CDNeQnAgPOAAAagBNG8J5vJQa4r2TVQIc
+        R0h1SS/Rau/r58FWdyc/vvGjux1C2q1jii2ZxRxxNHO0OtGVtJkkJNNDAPgufeOgiWL3DlTiiBH6OCt3
+        miY7En1gOtVUU1XFTOCLUDUEJzB36pLgogbCaZHsf+wFhTtQVLkG8BHvyN5SlLYK2W9RimNId9KMytR6
+        7L1sAFxpJx6daI54BgwAgQJ4gERRYIhaINteBOwAxvGAkEgzj/n9MqSA4ayyCa8Wpc6nZ5ttttq7yzit
+        PQ4JHHzINOZBBodSNLrSg24R5IXEZBLt+Zb+rTPQMbrDGb6yX6uDdx9//HFhljZ/4UEG9zWP9dsyimQE
+        sx8O5rb9K4JVnIwyoYlJ0gSlfWQ7wbMs5A64RYHKOgce0gZQpb4777yz3zGsfcYNubnmHkAURSzjKBYw
+        tCERgfokRbvX7tcW+0qRrS/hJMCWecwLKPf0p5uDDmnQX3PYTnFs4HFUqdtfsCCELubhVJzIiZg56UU/
+        ersGTN/AylUfBPu+tck1eMJbnSJIWtKsyakLFltssdrPCzz64oWebX8ncjBGcCI5JNORM/c0eGFSkQsU
+        9wigMLJUmBR3xqtdKvGbqqKGZ1FMqvbe3tg3Toqs51Kwb1yBH2F0UmBA0oZEwJKWXFf9gQd0QCBZdOmH
+        YF4sgu3LFVeKKWsXcNQVKuecWoluVxU1RwUWHekCIOQkq5gzDhTCkmUCZiS66h/d9SG+izNwuFTxrXA6
+        y6KjYGOssMIKtX/nmIKs7cshOa8x6c5+wemZ4LanEQGuKb0R5CUivOPdUoE0h1CEA1D02xKJWqdCflCX
+        yq3BUqSxMg6jAMDIAAiARAWwgMGoSEgN0BHRZF5EZ202pqxCLBfSsGyjeBK5ikLRTA8Zh76p9oHT6hb9
+        okPmDWF0Tj96R3dOSRcOkSjON4P7m9P5t7/QCGGKQc7mNE4hRlftgkmxhQO1j3qHg7AhlbcIxpvsyA46
+        mqMXMkMy0clLbd4bRBlPWRM6CpM2FDVOuwwOVCnFDxGKCD/P+Z4ntWAhi8ERylHGvT6ASURq0x9w1sKQ
+        KWVKz0QUI5szqYLpx/EUIZYSc4tke2GO6v0cc8xRRaD0dvfdd9dyEgKij3mji/nNzaHoEeFo9IwTek46
+        bzNAJPYTtnEuTlZr5XC9ZD/4xUERpZ0jePbTpiBUvHIAmRb2nJPT4Arm7s3n2kMmgglSI1krCdJV1jwG
+        aCZlvMiUQj777LNKi9IjZQBmPBMzFEhIQAhgTK49xDLceIABpqs2730LNN8Tqdmcyy23XBVy7pFsSxeP
+        J5YdQALPj/4c0jZKFKSPoiuHOYDmlCHb/HQ1tvkJkl0VlualjzZCZ7rGBnPT3zja8y792es9osxBHwQb
+        Fz7OI1TMSHOuLB2rqBVWDknyPYyTHcNlmyUrRSe0k0p5QSKYeKdPIpMyCFWOOwsV4cAAlojQn4GUCFCI
+        IdpMTAF9WlBEpyjJd/oxVh/vvQMuciMA1xcx1qOQl8iOrn5dEuHW3CWXXLK/n7XZ3zVJi/aZ9u+cw5z0
+        Abg9q3Pt2EAHbRxMOx0S3fSkP9uSDdigPTbqh2TtIlDUaoOl78xJL9sgTkhnTiiCrcfw9i3cYCRSjRPJ
+        cmPuIjhpGfsI1gnZnkNwrnK/d7YZlJIOFTH2kVK09dh4jCSUYJQr0BhAWuLi1TFc30iA0Y6wEBzAvTOP
+        1OUAQMSKBFV9sg0A8wd3ij9Li362Rv6wH1EhXCEmyqO3OUQTZ84Zu7mTQZwesZ3TIJo+7GLfyGw1ZrJR
+        HEEwySCKK8/+pkqRxY5ZZ521cOFAfti3JZUpEYhcV4RaCsNZIthYlaKJl4hNBRai27RNkCkNO5sm0q6/
+        /TGxVMLrDMygGBVyQ3hEmyvyGK5vJJ4e4wAC7ICL6KRN40phnFAVqohKKpbOXn/99SLCn/E4MVIgAgvB
+        loj8RaZnVTYbzW9sc5oPubaJyPZMRLFxObl9J518E1tjb2sXkV18n+wDL4TIQDKlgsrZuSPUwft13yvE
+        zOMembgLZzhyFb306GnQIZ18QNwn5E2aPxYXJbxLJDvXZYDiRRGAeGuhMaUN47STtSS2hKc9YLTkMoQA
+        A4AIlsIAj3jvzOV8HAlvv/129+STT/YDYu19//33K615zlLjHrgq1Py2PXTo0KozAG4uc3BgZCC2JTiZ
+        xH513nnnLYJFsXbO2Nrqnm3sde99MlDa4W3n4W+hpWKR6DQL1moHv3rZN7ODDfa4TriM5VuSSHYV3cbt
+        IRYJecGTQnCiGEjWAcQxWKkuCvL3TvbF0pS0CGhHfv4zDApbOyjpbNikiCVZQ5BEGK49gITYRHCiNymS
+        HolgOlqzOB2dbCMQZhxpDpEqTn3pihBOQi/RYk9sDIWk9Rpo5gmZ+hJtWXsRSYcQzbkQ7I8bfEfHEG3e
+        2Oeqne6u8IY1/UQmDgSSU0BFlfMFWcLyolgUaMi1FfUuKRxnvnU1Zj/BDAvBIkG0uSYCeYziw9YIaIQn
+        SYEffPBB7YsVKbZRiOflJgSCv9TnZQBW/flLkEzMWP0YGoKRC4wWAIJcoAGPABm4KaR8x3AAWIvpqDiR
+        btnm2WEMvW0x7I9tnZxFi2bO6A8CODCnC2nmDJmJ5pDqivQ4nb4E0aIaDt7TLwTHxthkSaGP/45KIIhY
+        +2K1g0MjOiBN8Up3tjuDsKQgVxs7LS2OY82DXIJHWPcSuURjCJYirEXOoa0FIZeo9iz0BrauGeijjz6q
+        NJ89HWnvGazAYRQQGUshgmhGa3PPeOAETADKFDyZBHTgAoG+9rRJvdZE1bBIcNABiOhBX8eUagbPihsn
+        WhwqkWrciPFDKL2I57TTJdHr6jm6E3axKSQnivWBqzGss7ZLfnJ1dSQ5bHgmhBlCLTuyk8MaS4i5OEGc
+        NkQjngMJTJyoL+rPZgGUsFYBW+wNxLusr+0PDYoThQxl3KdN6gOcjJD/BDLiZ0VpEOAiCsGEMqIXuCRE
+        Mx6AbXQAr92aAMl2RuRKbZ6lNPOJYntzJ1jWL1VzKmpjyzjWXRlG1LBd+8gkRJJEcQimV4iNaNcvGSjZ
+        ibA34r0gIi1WIti8sODM6gEZAcbmkmU4Bt2dLMqsCHb1LYzwKFCrinbDQGyT/J7rt1xHe0ATiVKCats2
+        wnuSwkWBYXvEUYDJCwO2tA1oEe99ayQjpFkSQIATYikLxKRmwlhXmUDkIVN0yDQq5gBF/5Aq04hw81tK
+        OK75HCRIz6IKMSE1kRtJe4gmnlv9pEhZBgm+0SdLCDtDcK50Rr6lLlV8RAWdatq+96uvvqplUsR6LwhF
+        uaPNEOydKLY+GzfVeS9su2oU0YDyQwIAEQkUKUN1ar0Qifo5XJA2EAhw5BicVyq4OIu06b05ko5JDExE
+        JKW5T9QiE3CEN6supTOiHwcUwdIXr7aOBiQeT0c1gGdFmGiWefxOLI37fdVPhLKKOQlyEByScx+SI97F
+        CaVS5MpsWX+J98EkNiM4hLtyOoWdolOQwNlYiir3llDBZQw1RbajiloRjGTXiPqCvsmQRTAxQQhQBCE7
+        a6X3CiRRkf+6zTkqA+LNrolCIiqQrjo0lrG160MY7ptEiPs8S3UAAlYEwYj1x4AyBpH6kQ5YTuDXME5i
+        fNH7xRdfFDAIlqVUpoCzlChiOAHnIL4Jya3QJ0S37YgldBW1JMQmXXNS+rQEB2NXOIsyJPuRxHpLV8RY
+        ItVFlkiOmT+RNZ6DG9kT8SI3hZkdg+inS/DumUBqRqZGhJqYJI0CDiiZxOBSHlAYweCsO6RNTYwjIbdN
+        wQGuvRqvBUv649HItf1xIsV77Vn9aODq2TtOIGodO7LFDw6WCro6CBHxfpQQ9YBRK5jXQYif4mQkNtON
+        HrEtJHtOOqab5zgjobf37kMw52U3+1uiYe7oVA0gWBCsACQ5DfSt7CKD+i5/RYNQ21bFrvRsjwwLEYxo
+        Dh/se6Ire1LkkhBL3EshvNXgxNqlOrWu6k8RxJGspzEq99p5X8hNxPrWcyICKAGKIM2+FZHWHWKdacU7
+        BItuEa2gAyBgjOkcWhain5M2TsAOegEIOJYap1wOa9Qa9IxOIZjIJuahE8fzHF1JntkQkmOf7+kAV0uX
+        +gGB+YNFa7FopoPMxw5OIOuoMeAug9qtWAJhYR9MBIDolbLpZp4iWColvCoeRuJxCJYiBv/Jjipu2PA1
+        gidxEOQNLpbSlvuQy9A2JWtLOyASFchFXGtIpCVXBOc0ifdKuQA2t6xjz4s067AfS1LlO4jRHptECPCk
+        cg4RgqMboRswZRLzIbklmCSCSYiOPaIfDrZnij/nCOb0/zxgH+8q4yBUVoEl58tPiP5Y0AmifbPsa0xL
+        FWG72kJEa2d/L9GKAESEIC+JeykEkAEiooBR3SnGOEi+dRWZbWQzKt7s3jvX3Idw7xPFFDZvG62DyUZu
+        UjTxrXVLdUkv65JiDzhSt4ilu4JMIen0ite3dvne+xDjGrIRiOCs/4BM1OpLQmoIppN7fX3LKWzTUuUT
+        7x0DCyRpWjSmQHRqpRjkYAKLvfQW6fCjC4djP53cww2WvZCZ6AnRLQGq4iq5+5RpxaBSG0BEfAg1JqLd
+        mygguY8YG6nmdM2c+gEKGNJnSM2a6zqYdG3EfMCwdPjPKf0hII+X0kSu0ysnQ0gHvn07273Lvl5GEyF0
+        QoaoyxWZpL0PuSHTdbCwX99kmszbYskZHQH7yVUBJbptUV2tuzAT9emvH8zh1Baens1Dpx4iArAJQyqQ
+        KWUA1bDChOe0CkUQKQ1aT0JuCEZaUlcMJYAwhzkzb+4ZAkBKItbaJPXEM0dGcMR3ChTbJgWV9RZh1i76
+        IFb0MF6GQJw0bf8uhatJpHUp0hbF+4gIzNU8JLa1BMdGz9qJZ/2iv0jjaNbV4EhHv8xJzWxRLyBWux9F
+        fvjhhxpfgahNKodbyI2EcNceQhJFyAjAlPHshwb7LyKF8MKW3Ih+CgJAieYcScZrA04MjoT4kJ8IoJzs
+        4FskuhJOBqAQ6h5oAY4AXgTbGjn5QbSdgMKFTualC5CTZi1TALfUiHZOIHOFXGPq134Tm9pIji0k9hH3
+        2hRonJW+yFFIZYmQXTwjUPpV+dOXHZYX/UW5As35hIASsSn6SEiGk+DoIZf4GLGUCMiOAhFmTXAv3fEk
+        WyhrHLFmUNDxplSoGiSqbIABIwUJEOL5JKC4DwhEO+ACFCB9D5REbK4IZYx3Id191qS8iw4cJ5FLWqI4
+        pm9Ev/Qn+unlfYgl+roah+R715bsiPbY64oQOtFNdlFNWyKMZWuHD7WNdRaGMo8tnuXUaRXyk12QarxW
+        Egj1/9YjSrP2JXIJkv3EV536otRib/PtryD8cKBwQarS3g8TBrde6MsJbNxFZSq8FiRGBxgS0gMEHZLm
+        9EcQUnk/z3RPGMIgxJknYwZo42kLIfoQz5k7uogUgCtu2Ja/DPUu30R316RC82fcEB47Mn/eR3wLL98L
+        Io6JSNs7/TmXKJVNYCCbKIgVWY6LLYF0gMvIBC5Dhgzp/gPbRo11jWhD+AAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="Icon_th175" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAFFSURBVEhLvZG7ccNAEEMZuB2X4tyBx3U4cAEKVJJ7s7HEDbjEfUhpjsYguFsu8Ehp+Q99vN8v
+        8gYop6lywO9UqTaUAS8/nzDPTeHpcnvNbu6rNmSAQQyaBuglIS3QZbqXakM9QC98Zke1oQyADsMGwDVP
+        cMaOakMGgHw7Xa2u6YiMARBXDXDSETkEZFneXH9TRJoA7fHFJSXhw0n56DGAXoOhPO9NdH0AAK/ZUV09
+        GQEgY9TD3sSvPQCkMN8lTzikNTEzotqQAZqyloHL/nkAv8NaBmZKtaEawFKKmVxhP5G9wRo6+pMzoJnP
+        AE50LftNgGICbIF93ZMALXFPh/woyoYATlQbagJkdOW6M34MgPk0QF2EYXNO8+PoPEREtSEBrIsTyPKs
+        qMVHfKraUAbMkmpD22mqdoDvr7fp3gEucgFcqGX5A6DeF3e4dU0eAAAAAElFTkSuQmCC
 </value>
   </data>
 </root>

--- a/Touhou Launcher/Properties/Resources.resx
+++ b/Touhou Launcher/Properties/Resources.resx
@@ -18051,7 +18051,7 @@
   <data name="wbawc" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        vgAADr4B6kKxwAAAMSVJREFUeF69fAd4HWeVtgkhWXoWCJ0NZdnN/vwsZOlhNyTsEggdAqRASCEJcXpv
+        vAAADrwBlbxySQAAMSVJREFUeF69fAd4HWeVtgkhWXoWCJ0NZdnN/vwsZOlhNyTsEggdAqRASCEJcXpv
         jnuTJRfJvfcWF1myZPXee73SLbq9996vpPd/z0hWHMeBhN39Pz/H38zcmbkz33vec97zzVzNiyZTmMpm
         MB2LYKjqHIq1Fmz1pOGOJYBcBkG9Bp2H92E6HASyKUzGwsr2tMWAoEEH71APguksplNJZDNphBx2RCY0
         sNM0nU3oaqpFld6CnjE1TDotjnkT2OKMIeJx47/TrIMq1G7chfqt+9Cwbf/fZPVi2w+gfuch1G7ajYpV
@@ -18267,7 +18267,7 @@
   <data name="wbawc2" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADr4AAA6+AepCscAAAAAGYktHRAD/AP8A/6C9p5MAAC30SURBVHhexZwHfJzVme6F
+        YQUAAAAJcEhZcwAADrwAAA68AZW8ckkAAAAGYktHRAD/AP8A/6C9p5MAAC30SURBVHhexZwHfJzVme6F
         yYaUS5KbTTbhprMhIdncDSQsKSQhlECATSAQeg0ldGwMNti4W7ZkSZYN7rg3XOUiWb333kcjjTSj0fTe
         u9pzn/dTwTJ2Qkiy9/x+j883X5uZ8z9vO9/ISa5wBIhGkIhGEY+E4e3twmgoAHtbPfQV+WgrzsHpAQNq
         BwZhbm1Cr82J7fYINlpDcAzp8Y9q+vpmFGRuRdmWPf8QlU5tb9uHkq37kJe+Adkr03A6OQPZVA63c1as
@@ -18470,7 +18470,7 @@
   <data name="wbawc2g" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADr4AAA6+AepCscAAABk+SURBVHhevdwDsGXHFgbgkxdXkgortm1ObNvWxLZt287E
+        YQUAAAAJcEhZcwAADrwAAA68AZW8ckkAABk+SURBVHhevdwDsGXHFgbgkxdXkgortm1ObNvWxLZt287E
         tm3btm33q68r/62dM+fOu5lJXlet6r3bvf6Fxj6n9fXXX5eff/65/PDDD5Vef/31Gj/33HPloYceKnfe
         eWd58skny/PPP1/T3n333fLss8/WNM//VHjqqafK2WefXS688MJ/lC666KIan3766eWEE04oJ554YiXP
         6Pjjjy/HHXdcOemkk8q5555bHnnkkfLqq6/W+b744ot9kfQXXnihxuEJSpoyL730Uo033HDDct5551V+
@@ -18584,7 +18584,7 @@
   <data name="wbawcg" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADr4AAA6+AepCscAAAAAGYktHRAD/AP8A/6C9p5MAABqXSURBVHhetdwD1CVXswbg
+        YQUAAAAJcEhZcwAADrwAAA68AZW8ckkAAAAGYktHRAD/AP8A/6C9p5MAABqXSURBVHhetdwD1CVXswbg
         E9u2nRVzYtt2sjKxba7Ytie2bdu2bXvf++x/3u92zpzJfN/Nn71Wre7erKq3qja6z2n98MMP5bfffis/
         /vhjueuuu8oTTzxRnnvuufL111+XP/74o7zzzjvlyiuvLN9//32tp778jz76qLz77rvlpZdeqnm//PJL
         pY8//ri2eeONN8pjjz1W7rnnnvLss89Weu2118rLL79cnn766fL555+Xf5KM26dPn3LhhReWiy666B/R
@@ -18759,7 +18759,7 @@
   <data name="um" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAIAAAAhGetkAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADr8AAA6/ATgFUyQAAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQflAxUOCBUFoL4F
+        YQUAAAAJcEhZcwAADr0AAA69AUf7kK0AAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQflAxUOCBUFoL4F
         AAA4QElEQVRoQ4WaBVRb2b/vD26l0BZKFUpLXabTf92m7u3UnbpQSot7cXd395DgECEECMGCSyAJBAmW
         IAnBNcl5G5g7d+68d9c767vO2tmWsz/7d75776xAgik+3M6G6Vy4fRym85ZEHV0SjQM3ceAyNtzAghv7
         5ys4MGlIUDTII7InCod4JUPT+YzJ6LapIjq/lcFLJU7R2eMNTGYsrjska8AX0YsgdWXWdhqm0iPS6fEJ
@@ -19006,7 +19006,7 @@
   <data name="umg" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAIAAAAhGetkAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADr8AAA6/ATgFUyQAAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQflAxUOCQh/veOd
+        YQUAAAAJcEhZcwAADr0AAA69AUf7kK0AAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQflAxUOCQh/veOd
         AAAdxElEQVRoQ43adbSW1bbH8QfjgGK3YqAYSCggynYrCAKiUgICiqDScQEDBERRsLuxu7v7GpiYF+zE
         QBTwYNdRx5Dzefdv8559BMa4649nrHc9K+b8zt+aaz0bit9///2bb75ZtGhRnso/l5QFCxbMnTt3/vz5
         Kp999tnnn3/+ySefvL+kvPfeey+//PIHH3ywcOHC11577auvvtJnxowZ/1tVXnjhhZkzZ956662PP/74
@@ -19140,7 +19140,7 @@
   <data name="Icon_th18" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAACxAAAAsQAa0jvXUAAAAGYktHRAD/AP0A8DOGbmwAAAAHdElNRQflBBQMAhiI5kUp
+        YQUAAAAJcEhZcwAACw4AAAsOAUC+4UEAAAAGYktHRAD/AP0A8DOGbmwAAAAHdElNRQflBBQMAhiI5kUp
         AAALXklEQVRYR3VXCVhTVxa+YLEiRClYlakrjLhUxa2WWlCrjq22Y8fiTG21LjioYLVulanValEUFFcU
         q8KwyhrZlEUIoOyShCSEHWQTkF0MEEJC8s99j5Bi7ZzvO9+99+W9+//33LOF4E+kubkZ5ubmIIS8piYm
         JggKCsLy5ct1z8zMzDB37jzMnz+f/d3Q0BB2dnZwdnZGaFgYQrmxeHf8BBgZG+PmHX8kpmUjJjEV06Zb
@@ -19195,7 +19195,7 @@
   <data name="gi" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAACxEAAAsRAX9kX5EAAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQflCwIHKSwkVTyG
+        YQUAAAAJcEhZcwAACw8AAAsPAZL5A6UAAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQflCwIHKSwkVTyG
         AAAxc0lEQVR4XpWbBZiW1db3h5mhu7uUECVEWqS7e+juzqG7O6SkQVJKQJAGQQlRQkVSRDmoiGKhHj3G
         //3972cexHPe+D6ua7F777VXr30/E6H/49+5c+eUO1cuRUREKCIe4PL/B+LFU8p4kaodHaXTCRLotwTx
         gYT6PSq+fokXpe8Y+5R9P4qIp0+Y+21EpH6k7xf6/kn7Z+AhY/fpv0X9GvAZY99T/gg8mhMZXz+lSa/f
@@ -19413,7 +19413,7 @@
   <data name="gig" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAACxEAAAsRAX9kX5EAAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQflCwIHKzACYgJL
+        YQUAAAAJcEhZcwAACw8AAAsPAZL5A6UAAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQflCwIHKzACYgJL
         AAAcA0lEQVR4XpXcVbAmxbIF4B93dxucwd3d3d3d3d3d3R0Gd3cncJfAecBeeIRAIgjoM1/OXvvU3gyc
         eyciT3dXV1dlrpWZlVX/5vS6//HvzTff7Gaeeeau1+t1o4wySl3/P+Kbscceuxs6dGi3++67dyeeeGJ3
         0kkn1fW4447rjjrqqO6ggw7q9t9//7oeeeSR3THHHNMde+yx/XL00Ud3hx12WHfAAQd0++23X3fIIYfU
@@ -19545,6 +19545,444 @@
         GQEgY9TD3sSvPQCkMN8lTzikNTEzotqQAZqyloHL/nkAv8NaBmZKtaEawFKKmVxhP5G9wRo6+pMzoJnP
         AE50LftNgGICbIF93ZMALXFPh/woyoYATlQbagJkdOW6M34MgPk0QF2EYXNO8+PoPEREtSEBrIsTyPKs
         qMVHfKraUAbMkmpD22mqdoDvr7fp3gEucgFcqGX5A6DeF3e4dU0eAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="hbm" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQfmCQMUDC8PJ+ZZ
+        AAA4v0lEQVR4XoW8eVRVa5rm6R+1Vld1r+7q6q7VlUN1VdbKiMw73+usyKSAzIojAgKCoqKiIAiKDIKA
+        gqAMMs/zPM8ggygiqCDzPAiI470ZkZFVGXEj4z79vN/xXI2oqGrXetfeZ3OG7f7t532f9/u+c9bZGJjD
+        Qm839Ddsh7OVPRwtj8DR+gicre3gYH4Yh4xt4GB2GE6W/Jv1x3DacxSuNk4qThx0wSnb43A74Izj+xz5
+        WocPcRTH+Lw/DXnNQaO9OGBkjQO7rHF49z4cMt0LORf9DZvhecYdxlv0cNjEBnamB3DU8jBf5/jx9fuc
+        cc7BHX4nfXDltC+8nM/D0/E8PBzOwt32BFz2as7Bif8fCXsLW7jY6KIt7Tz6cr0wWnUF4xV+GC3zxUSl
+        P0bLuc8YKfXB8xIvxnk8L2MUX+D+BQyVXcRg6UUMF3tjpMQbw+XeGCr3wlClF4brfDFUfQkDxV5ozz6H
+        9vIr6GmPwEB/LJ4P3cWTZ9FYXMnA4moqpufvYnAoCnV13qio8EJtvQ8qyn2QmXwcVfnnUcpt6V1n1Ge6
+        oTHnBBpzGTnH0JrviPZCZ9zLO4r7BSfQU3ISXYUn0Znjiq5cF3TmH0dHnis6cpzQmeeI7iIXPK47hyet
+        Pli3R98c5jrG0Fu/lRfDDgdN9vLi6sNcdxeMt+rDSs8U9gQtF+pTwM57PwI+Y38K553k4h7Hif1O6uJ+
+        CvR/FEd5MwnoQ/xMW7P9OLJ7P3Zu2Y7WhgbsNbWAtYEpbE32qRtNoP38Wn62r5sXYgIjcSckGqEXr8Hv
+        hC98XLwV5BP7j6nnawFL7NHTQ95NV3SnXcBw9VVM1QZioiYAk/VBGK8LxDi3YzVXMVzjj5HqKww/DJf5
+        YKTKFyOVDIIY5w0wWsQbhDfBCAE/r7iA0VovPC49j7ZCL/R238D4ZBoWlrMxMZ2IoeEYPB28iYGnEXjw
+        KAT3e4LRfu8qKis90dYehOfD0Xj2/BaecftoIAyNDb7IS3RBXowdqtKOoSbNBbUZx9CQ64ym/GNoKziG
+        jgKCLHZFe/4JNKc74l429wm6I5ugc4+hMc0OBVGHUJF6ElWZx7HOSnc3LAjYYONWpRi977Zg8+ffYNPn
+        X2L71+t58W3gJIr9HwCWi3nuqDsuOJ/jxT2lIH+EaP9J/Cl0RwVBFHrImIBN98PO7CAMt+zAyNAgEu7E
+        8fM38Jz28vih/+6mueJ+Cck37yIjNh2J4QkIOR+CAPdAXHL1wcmDx9W5KRWrc7fjzbMPPq7maEu/iIHK
+        AIzVX9NAbQhkBGNUgqBH62UbjDHeAGNU+mjdZSreDxNVlzEpyi+l2ksuYaziEkYrvTFQ6oGmQg/0dIfh
+        XkcoOjquoedhKLrvX0NXdzChXiPMq6ip8UEDATY1+fG4POc6+voj0PtItuEYHr+N6aVEdHYFI5WAs2Ns
+        UZbojOrUE6jLOo6G7OMEfIJKdkFr0VE0Uc0t2VQ2Fd6WS8C5x5Fz4wDyI0+gPjUUzVlRzATXsc5yhwkk
+        jLfpYtuX66FLwHrfbsG2r76DAVVtz4urVPAJXNl3JjAXG8cPgE/jvEB21MRJpmxnPkcDVRufwv0QvEnk
+        eXamBwnYhinbCpY7jfD99+/Q3NiMb375GfYbWeAI4R9lmtW+Ts7H08kDcaGxSI9OQ+y1OwrwNY8Q+J/0
+        x1k7d8YplgtnBVlbeg7t1kVjhicelFGhhDjeEIqxpmsYaw7BKLejDUEYbSR0gVtDmFTxWK0vxir9MFlL
+        tTeG8DFVTuCjVPqz8ktoLvBEU8MVtHcGU6XX0f0gBA8fhaPvcYQCKNvWNn9UVV1kar6EWoKurvLkjRBI
+        mIG8EYLxmM8bn4rF/EoyZpaTUFvljdjrNsiPtWPKdkRFihOq05zQTJW25TMKHdFKwG35TminohuznZEQ
+        sAdFN3mjFSXy/1OC8dZSDDcUYp2FrgkkdusYUrlfY9dmXez4ZhN0qJ5dm3YwPR/6I+Vq1SwX2pWApe6e
+        J1RPpzMqvJzPUinn1fH/v1QtCnYhZCcrXnyTPbDZaYoLp07jxx9/i457ndixcRMsdY2Uyh14HtobRd73
+        9OETCDx3FeGXwhDkEYjAM4EI84pQ2/NHz+GcvTvOHDmpztXZykHdINYGuii67Y6eQqqSCp5uu4mpe9cx
+        0R7KCxKKiWbZXsMEIU/UX8FELZXbeBXjhDpRH4jJlhCVzkeqfTFeE4i+Yl/kJJ9GJ1Pz1Hwill+nYZYq
+        HHgahc7OEPR8gF1f74sy1vTaWh8UFpxFQuxRJN91RUrScaSlnUROzml1EwyPx2Bm6S7GCDs71QVx16xQ
+        EHeEkI+gMtke9elM1YTZzJrcXOCM9uJjqEx3QIyfNcrv+OJJVQYmWgi3uRjDjQUYaSRgcz0TmOsZwVRn
+        J2uvLnYSqs43G7Dj240w3W74PwUshkpAnrM/qaBqAV8+eZEX+TTh/fl6rAGrDXnsoAyXEdNzXno6/vCH
+        36OjsxvmVLMRz8eOCrZn+tZkBc17HN93jJ91gZ/lB98TPrjs5ofQC6HwP3WFWcSD5eIMz+v0BwVLvT8M
+        m13GuO3nQGNyBcO1IZhricBMWyim269jkoCnWsIw0UbgjcFUawAmGvwx3hJM8FQ7H4+38FgT03vDJYwQ
+        elOuN+61x2BpLQcLqynoeRSKqmpvlDJt52SfRFycPdJSj6O8zEsZq7xcd9wIZxrNP4N794KYpq+hbyAc
+        Twaj0NTij+aWK3yfJCy+TEY7FR4RtBc3rpghK/oASuJtUZFoz5rshDqm5tZiN+TFHcTty/vQmhqB4fp8
+        nl8xnpSmIjvCE70lSVRyEQHrGhPwLqVg020GVK0utn+zHjoEbLHDmA6UgFlD/3vAjj8DPn3YFd4uHiou
+        HjunwoumS9Kk2wEXBfLPw9UAFgUfMLbG1i+/xeLsNPDTT7jf/RBWJqbQZ5mwZf0UBUst1b6XOOkztqdw
+        weEcP+c0P/MCQi4EE/YlpWABLJ+tAMu5S5YwMoO3owE6srzwtDoQU03XqWKCZYqeZEw0hWCqPRzTzWH8
+        G5XM+iyQx6QO17IeN/hRwdzW+FG9V/DgXjTe/lCHUSquhk760eNoOuUUDA5HUbnXWXMvIyHeHinJTkzR
+        Xoi8cRjV1T7ofXwdY5N3mJJT6a6zsUCXPTkfz9ffQCeN2MLLFEwtJqGlNRAFOWdw6/oepEftQykBV6Qc
+        RX2OC8uSDRIDHPEw9zZGmgpZWkoxUl+IppRwxHg54Fl1BssOAUt6NmcaFMAmCrAOFbxeQZba7CCAtWA/
+        wNUAdmCKPqpcsxgrUayvm6dSsoD2ciFoGq+zdidZk13/BKoGrLxebhJRp9Tf/ZaW+O0//xbv375He1s3
+        rIzNoPvNRjppG+UFHC3Z7nx47fF9Tjh7+CQ8jpyB+2E31SoFnr3KLHIOpw6dUArXGq1jDEfeHAL4lMVn
+        qAuxQF/hRUy1RWGGQCdaQjFJFU+0EPo9KrrtGtMx4TIm28SI+VPFTNXNBN3sg8FGX9SUeBJuDSYms6la
+        H0zNZGDtdTlWXxcxxcbhAdNze3uASs3pGS4oo6rL6LYHnt7E+MwdzLLWzrN1WlrNw9JKDuZWkjA+H4fB
+        0WjMvkjk3xMxtZCE+3yf8lIvRARYIivqIJVsx1K0Gzmhp2nwEhXEMRUleFqRiVhfZzTGM+NQzSpFWzBF
+        m+3YpVK0ADZiDd5Og7Xt6++wf6elRsGfgJWQiyZpVQtYFHzWzg3ex8/Dj+2LQL7oSshM1x4OpxVgudif
+        AtbApapt7HGELZLZNkNkpaZgbWUVT/v78fDBY/bDZ2GyXVel76NslT4FfIIKPnuY7ZmdBvCl494IOheg
+        aq+YKwl5rgawKJgtoJE5Tpn/PZqu6qDv5m6MF57FbNsNQgxRUKebBSwvDtPwBNUjKXmsXRz2VYJl7W26
+        gueNl5maz2N45A5mqLK6On9Mzabj9ftKrL2rxNxiJkYmY/GM/W7rPX/C8WT7wxZrJh6zfP48Qc4sJVGl
+        yZhjWl9ayVavmaPBml1OZaQTMP+2lML+uRCT02loZfouL/NERPAeXD21CyU3PPC0KpXnR7A0VAJZYHZn
+        RyPq3BE8LU8h8A+ARb0fARtiF+ugtEd66zfhMNsXe/ODKkV/CljiUwWfOuRCQ3MC7nYnqNqzCux5J3fV
+        NkmIoj5NzwL7OA2avcVBeLqdha2VDXS+24iF2TmMjwxjfHgIYyNjSIuPQ3zEDZxzOqWM1h8Bpns/a3sa
+        F+zO4hxTtLeLp4J86tDxPwtYeu4DAtjsMzRc3Y5HYXoYjjbGRI4T4QZjhsqdbBOwmlo7do9g2atOsFaO
+        NftjlMdHqehBgi5KP4Oll2no7btBIxVGJZfj1bsaLK8VY3b+Lh71hiH1jiMiPC1x95YzxtkTv1hLw+Ja
+        sgI7PBmttkrBy0VYWqrGykotVlZrsLhchtHxVIyNJ+EF95dXS1HPElHAm+qqhxkKw87gWWU6xtpKMNbK
+        oKGSWjtYk4OMqydREuFFuAXKQf8R4N3bdzJ2wWirHlulTax9mxVguz8D+FMFS2jr8OkjxxVo1S45n1Fp
+        WwB/qmDZamOfsSVmJyfw/t0rBPtfxsjwGEYGn2JlcQ4/vHuLoccP0VhejqSoOAJzVE5Y3kNuFnnPc/Z0
+        7g4eOM96KzXY0+k8j38ELM+Tc5U2ye0Qz2HfYZyx+owK3o7eQF0MR+pj/JYBxlP3YqrOi2q+TtPFetwS
+        hPF2tk+tBMwYa/Snehk0WvfZGjXW+9EIpak+d3k1B6trFVRwFaFnUm1XkRB0GFW3PNFXdAfTw5V49foe
+        Vl8Vs64m0JCl4cHDKEyMFeH163a8ffUAr1YGMD3eghcLDZh/UUhHHcR2yg8zs7lYXilj+s9CWOB+JHvv
+        R29ejEq/Y23Fmq0CXIzewnhEuO9HTw5LQLO0SAK5QFI0TZbUYAJWTpppWm/DVuhv2AJbAWx24I9qr7pg
+        CrBGkdIqiZpO8QKetj2h2hcxVxcczyrQ2sEPUbqm7mpeI3U3MjQc379/B/n3em0N/Q8f4uXiPN6vreLX
+        79/ixewUXkxOor2mHj6s7w5qyFE+96hSqpgpL0KVzxLA4p7FWAlcOSctYHHzF114PseOw89uPeqDtuHh
+        DT2MxRthIn4XJuMMMZpggvFiV8INYG2+ptqnyVZJ3VS2tEdNwQpwReppKiwJL98VYmImjkAy8OJlOdNz
+        GR72hiPzJtuYO5f4+jKM36/H2tIz/l+m8eZNG0ElYuVlGdZetqKjJYPHevj/7sDaWhtv7hKm8jBMLyXj
+        KV11SckFZocYrK7yxnmRjxbedLd9Dyr1TrLHVeol4Amqd7g+F/l0zsmsv0/EPbMej1LBo1oFSwhcCQFt
+        sFGHKXqLGkU6wtT45wF/km4/XFBRlTakB5X2SULULUrXql7UaKljgtb6RvzhX/5FAcZPwO9/91v84z/8
+        gB/evsGrF0tYmZvB2vwcnvU8RITfNWX4XGw0n32adVcUe/GYJ0F7cF8D+MR+F3Uuf6Rgxon9dPyHjuDS
+        wc9RH7gdD8N0MRJjSMCEnMh6TNDPY3ZhJOMIxtm3jlNFU1TzeDNTNtPyeJOoORjlaecx9yJX1dzJmST0
+        PrqFlVcVWFjOQ3m2BwqCj+FpWRxmH9Rjrv8eXi0N4h/ezzAjPcX8fLFKxasvS9HKtqz7QTjmlNlKx+KL
+        HDQ3hSEj5RRTfwTbLOmvI/ByrRqzczmYoFNPjT+GjuwIno+k52KCLsIQ26PKpBCKSg+NcZcxWJuNYanJ
+        VK+Yr58Ba+uw2Y6dqlXSo4L377JU48NiULSQtRdMLp421WpToqhHGwJZ1CygZV+j+A+AqeC9BmYYHBjQ
+        wBW6+MOHrebfP7x7g9WFWazOzqCvowuR/qFM0YeZZuU9HPm+pxRcgSr9sI+LDx97qc8WwHJeWsDyuoM7
+        rbHPcBcC7L9EQ4gOHt/Up3KNMXNXABtrFEzAEzcNqGwzjFW48wJqUvRE6zXWX9ZkKrqWLdbYRDbevm/C
+        ixc16OpIxK9+04n+gXikRrogL/QMqmID8LSxBMsjA1ie6cX378YZA6yveXg+HEcDlcA2KRppSa7obguj
+        AbuN6YUUDA0mIj32DFKiXJCZ7ob62gAsLJawrudgZCwWLfeuIOmaK4ZqsjFWX4QBtkIZMd64HeWAO5eP
+        oD2JpYXperRRDFYRU3jJR8BaFQtgU6Xi7TDZaqjMzVGamz8H+FMFS7iydXE7cAwnJHiRtSFDmlrAEk58
+        P+d9RzA9MfEBJ/Avv/8dfvfbH9X+T1T1D2/WsDQ9ianBQTSVVSmHLuegyQDOTP1Sdz1VHZZJBt/jlz4A
+        FvVq6r0WsB1v0oO79mCfgS4i3b5F0/XtGIg2xFSCMabu0mjFESz3JxJNMXWHx2INMZKwExOlTrxg7H07
+        rmGYih6h0eqp9GN9vIy1t/lUVq5Kq2tvKtDZEQGvE+Y4arYDHnZWKIqNwHBnA2YHOrAw1Uz1llGtmXg6
+        dIP9bgSGRmJQmH0WmddOo/iOBzpZBh4N3EROkjuuXziA22H2NGonMdB/V2WH6io/VJT6If2uK2ruBqGZ
+        tTY+wg35ee6IjXREWcRZ9GTfolGsoPOvYo1mhmkr19RgTR02JmCNis25lREt/fXbcNCYLQoVIEblU8Da
+        0KZqBVtdWMLX1me1pdLl74R8bC/dLN/LxtASF06cwsrSkgK69nIFr1++wn/9zX/Dj7/7Hf7bb/4Js+Mj
+        eP64D531TYgNjVJwpf6KerXpWcajz7P+ygTDpeM+TNUyk+SiniNwJeScZcLkIFstyx2bkX5hE1qu6+BJ
+        pAGmbhthmmAnY3cp2NPJZpikkifTd2MyhceTd2Ikex8mGi4Qcohy1jV559DbH8Gam876m4TGpstooMuu
+        JYD08FN4WhKHl711WOtrxRLT9FJPEx6U30V3Qwwedt9C/6Mo1tZQ3OsMQtrtUxiuTkdnZiRu+jjjqv8B
+        hAcfhvm2z3HB1RQxfg7o7YhmG5aGG0G2SAw6hwfd4Qjx34eYyCNq6LOs0gs3LuxHS+wlPKWyZ/vaMf/k
+        PrcdmOquxzorfZMPgKniHR9UzJBhShlFkqlDma6TC6WNP4UsF/L0YZoeJ7Yrbh44ZeeK4wcdVX97yGgv
+        HM2P8HV2atJg/y4rdeO4OTrhfmcXfvOPv0JZURFmp2bx7t17jI3N4NHDPhSnZ6EgORM3LofClfVTBiu0
+        I2cyciWpWQBfcr2ohim9qV5J2wJYnqcFLGZOxrn3E7DVjm9RFrAd7ay/Q7d3EvAuzLAGT8btxCRT9XTK
+        bkwlMzJMMJFE6MlGGGWdHqOyRypOor/qEuqqL2OWRmjtbR6W36az572DnCx33A53QHGMJ6ZbCrD0sBEv
+        CPdFTy2We2qw8pBK7qjB4/JUtBXE8mbwRR5f05oThTkeTwzxhqWxAVyP2cLafBv+81//B3z2N38FW5Pt
+        KM/zxtPnUYgn0PJoH9RWXEFVlTcKCs6qaceMZDfkBLqhOe4KFvrasDjyGEsSw/0Y7WzCur0GpjD7kKKt
+        GAquqJg12WjzDmz7aj0VvRMOloTMi/znAEtcOeWDsCvsE/v70dbUiPqqSmQlpyI84Bp7XXfYGJlhJ9O+
+        8VZdOB20xZ1bUSjMzcPduFiUFpdjeHic7cMA0lNz4WTLG2nPEapfM9Mkn6lN9+LWZTBDFCyqvXr6Kq6c
+        vKJMlihblQpl6KQHtlfzydLuHTK2wmHDL1AZrIPOiB0YvkuAhDudRMUmU60pJphON8V0GtUrgAl8LGEX
+        hm/txDjT9XM67ZrbhzA2lYO116VY+5496lohIw/d98MR5muDokgfLBPmal8zZtorMUW3O9pQjPlO9rf3
+        q6nmKvRV5SAv0wMZkWew2F2DUbY0UVc8cDP8OhqqynHB/RSOHNiHf/9//G/4xV/+P4iPOaGGL1NuMg3H
+        XEFZgY+ahZKZqZrqi7jmsw8lkb5oz4/HwuAjTDx5gMknPZh59hBP2mqxTlZUWMqEA+HKzI2FjgayALZg
+        6H67CbobN2GfqRXs6GLlYosyXGS1xieAfVw9EeYXqFLup//+6R9/jSdMteEhVOLRowQbicmxEfz0B9bZ
+        77/HFV8ah6RM3L2bBl9vfzgcsIWJyhqHlPo+hStmTVowScW+x70R4H4VAWcC4ed2mYqWHljcuqYNk9Ig
+        88uHjW3YDezBgZ3G8DjwBWoJuCeKDjqZ7VGiEaZSCDlNA3mK2ylJzak0XrwBJvj30ZidGE6kipnGy8PN
+        8WwkEW++r8DquyI63zwsruRieDwemXdc0cFUO9xUjLQwH3g6H4TrQXOkhvjQpJVj/n4NFrqr0V+ThbQY
+        mdGKJ+BaVSc7itIw0NOB3PREOBzaj10G+vi7f/9/Qv/v/gbJd08iK9UV1Xf9UBwXhOqKS2rRQH2dNzLS
+        PXAj2Be5ibfRXleJwUc9GOrrwfjTPkwPPkZrVR7WyQXYt9MSVnq7GSaw1jOFNdO2FdO2la4JzGi4pC+2
+        3m3GtHoCh5lm9+wwxSGaFluT/SoOG+9TF9Peej+WFuaI9Q+q/fnpJ2mBfmIa/g0a61uQT8Wuscf98cff
+        4fWrN3i5+gZ5OQXYv3cfrEzMYLhFR91UDnwvASwKlDFlgSvmSRz5+aM0V86eCDjtj6CzQfDn9hINlswB
+        a8afNXVabgxZwCCtngA237oByd6b0Ri6A49v0ymnESjhTqUQpABNkn2pu0zZ6dymccvniIrHU3ZiLNkE
+        FTeNMTwWh+U3GWyVkrHwIhWTcwkYHL6Fikxv3Mu8iUB3B3z1i7/Gv/vf/zX+1//lX8HeklmAznbhfh3m
+        uyoJuQadhQmYbq+gsqsxc68Ss121eDHxDPkpCfjy3/4bGDI9H/q7v8WxnesRdcMRt3ys0F+cgIzoi1St
+        L5oaLxOwHwVxlG1VGg1aMyafP8P8xCgWJ8cwOzqEmZFnaKkpxjoHs0OqFRLIe/TNVPsi87J7Dc0UbIFs
+        tEUP+pu24cCefYgICUdMeCT8PDzhZs82ydYBp44ydR51wUHLvchMTVbK/cPvf8QffvoRv//9P6P/8WP4
+        X7mKa8HBuNfeidHRSdRU1SE06Drs99vyBtrEmm/AzzVnr6uB+6lypfWRluuC4zk1JOl/+gqCzwWpuV8/
+        1l9J124HNKNlmvT8Qb2yFGi3DawNTOC293NUhuxAa4Qunt2hg2YqniZQATzO7XiShBHGE/mYYCfSCT2D
+        aZrApxKM0Mea3V52GqtvszC/fJetDvtX9rCPn4bjQW84ipI9EevjgmMHLGF36ACCr/phy8Zv8eV//AvU
+        pt4i3CrCZXRRyQ8Iu7MWMwK4owpznVVYetaNB20NsNej7/mL/xt6f/WXvKENcfuaI1IDXPC4LIOm7AzK
+        Sj3R0nIFkREnkRgfj8qycsxOjOHdyhLevFjA66V5rMxOYWFyBBWF6VjnRAMkAwjSDglkG0NzwiVg1mYF
+        mKqW2L3NEMbb9HHQ2gbh18OoyEY8HxzC/Ow0lhbncL+rG7GxSfD2uojf//afpddR6v3pDz9ikM9LSc3G
+        pUv+sN3Pzzp0GHtMzWGiY4DdbMVsdlmwRu5RipNZI1nw97Gv1qhXFOrt4qXmewVu0NlA7lO9bJFkssHV
+        Rmqvpj1ypF/QwpWttc4XyLq8HXUReuhlSzTC1DuZYYoJpuRpqnWKrnki0xST2dwS7ngmFZzDOpy1i3/f
+        hb5oXTRlOdM1pyj1Ph2KVIDHp2PR1HIVpaVeyIl3h9seQ8SEXUNWShKaWE93Gxlix1/8O/g6HsSEqJiA
+        Fwl4tquaULWA+bijkjdAHZ40lSPSj6VmnwVCL5zELf+TiL/ixDiBuOBTyM86jxq2aG1t16jeM6irbUJ3
+        RxfeLi8SrAauhALNaKjIxzpHCzvVukjIsOQBI3GcBL3TQinaWl8D2lrfXKnZdCuhsFd2OGSH+Nh4PBl4
+        hsnJGTzsfYLS8gYkJ6ejrqaKfH+PhflFdHf30vU140Z4NIwNjLDpi2+g8/VGgtVXWULaMAVXTWzIqg1J
+        y+KWNYMlWvUquKcvU7UBNHRXcPnkZfidkNR8Gm772Yd/qLvObNNsTWmspHSYs55t+BZRpzahOlQX92IM
+        MJREE5VqRqCMDDrmbPa+jIk8c4zlm2E8m/WY+zOF5pjKN0XLLT10V3tgdiEJr95lq9RcW3sJL1bS0Vwb
+        hJqMIGTePk2X6wxbMx3kpCWirb6c2cwUX/2nv8SJ7/4ezoZb1QoLqcGLVPI8AS+zjVrsadCA7qjG7L1q
+        VY+f1eWjvzIbo6zlvVRtXtgF3Al1ZC0+wevow777GlqaQxB09SIaGpox/Owp3q5o4L56oQH8moIT4AtM
+        1+uOWhwhXNsPkG3V7NFhOs8DO63UMta9hhYqbAwYhL6PIasdpW823mEAYz2BfQSXL11GdFQsQkMjcO7c
+        efQ9esa7uwv5BeVUtS92MMXvlBpLIyfvIVOA0pse4g0lC+KcrGQiQTM7dYLAZKzZ3dZN1V0Zb75MIyUp
+        WSBLmpZxaHdbzYIC7cCGvF7SuzhneU/99d8h2GU9SgN10BJlgEesp6OEOiFAC8wZVG0RnXP+bswWWmCq
+        xAoTBDtTaIoBmqz6hD0YfhKOxZcpePMmm+k5E5PTcepCL61koTTLF48KbqEu3gdpQU64emI/SnPSsDI/
+        g3M0S4f+5v/F1v/4VzDd+Jka+J9n/Z0j4GmqOOmaNybvMT2zNkuanu6sxPS9Cu4zuJ1ljZY6XRlzGQk3
+        jyI37zQqKjyp4Ctsj3zougPRUN+ExdlJvFldUkC1ChbArxa5JXAF2MFcAGsha0L1j1SVjcBl7JP4AHg/
+        4e8ztFL12tpgtwpLfWMqWx+Gm7dj09ffwMZyD04ed4PDYTse0+FNsptQLRlWBKtJx1L75XOcrY8oY6RN
+        y+KSZQJfhiBlEEPaoOBzwbhK1yxK1qx/FrjstxVcTVukXT25n4AN13+BG26bURiwFc039dGbYIjnbH8m
+        C6jcot0YK6FaS80wXUWoFVYYr6Biq6wxnG+B+tu7cb/BC4vzyXjFmvvyfa6Cu/w2AyOjd5gafbH8Kh1t
+        VFNPYRyGKpPQHOuJR/mRGCO01zOjeEJX7HrACv/lP/xfuOF9kjDLWH+rNcaKabmvMhdz3XWqD57jsTlC
+        F8Aq2ssxQzXPtZeh7JYPEqKOIo+AZU64stILGWknkZachNaWNjzr78X48CDWFhd/VvDakgBmLM0IYAEr
+        Kpb4CFh7TAY5johbVu2GjYIugER90mId2ClbK7U4QGIfj+3bxRTPurrP2Bz7uZUxbVGqOHZRlwwdaud3
+        NfPKmiFPWbQus0ICV0DKAIYshQ29cF2t1vBxvfgzXEnfGrh8vSzLJVx79sxSUiy2/j1iL2xBYdB21LMl
+        6mXNHSLcsVxCLTQjZFOMF1GxpVaYq7DGfMUezNfaoCvLAi3lJzE9w3T8Nh+v3hew383CGlPz6htCfs12
+        5mmUWkW5wv2e3lCU5QZgurUMHanBKA45hbHGfCw9aMbLJ91oyk1CV3EaplSNpcEiSAEsQGcV1Fqqug6D
+        7JWrkiLptGsV4CnCFchTzUXIDz+PxBgnFOSLwTqP6hovhAY4qIzp7x+AwMsBdNo30dvzAK9ptFSqVnA1
+        kNfJhdXA/FTBH6E7WdopR+vIfTFAojpZI/VpyLFPjx9hDZRRqyO7DyiQEuoxQ41t09RpFtAJXFkwoJn6
+        k7FlUa2sqxLVyjLYMK9wGqrgD3DdlaGSsW7N0KdGva7sw6V+m2zVhaP5l0i7tA2VYVvRekcPfXTCw0y7
+        EyUWTMfmmC62YErmY9kvsMRUsTme51mgIdkGA31heEmQUmvfEO479rtvfpC53kK8fJuHpVcZat1yfYMv
+        b4BcjExGo7nxKmqzwvCipwZVdy6jITGE/S1r7Ye+V3rdOW6l7i4IZDn+oB6T7ZWoo7suvBOOi0f52TU5
+        yk1rFTxLyO2pEYjxP4LkRGcUFp5FVeVFRN48Rj9zHVmZeSguKkdRQSlqq+vQ3tyKVzRbrxRgDeS1hVms
+        k7QooSBSUVrAjgT7M2T+Tf2dUDT7dvz7x5tC0qyEFqYC+gG67Mvf5LnyWq1i5TMFrGbSQKNaASxtj4xO
+        iWrDL4YpUyUrNWSFpGYgg1AZx/Y4w2UPTRXP5TBvqJ0bN8Hz8JdU7VbUXtfBvVh9PGH7M5JHE1Vmxfpq
+        QQXTNVO907mMQivWWjM8SjFBc5ErZuaS8Ob7PMKlYt9m48XLdBqrRCysZBJyGYOtzGoxnjxJpIkM5uNS
+        LL/IRf+T26guC0ZbfgIGqjKRF3kR/WXJWOqpU3CXGAJ3TtIzTVVtajSifd2RGuKLrsIkTLMuz1K5Ux1U
+        7Yf6O8fe+H7uHcSFOiEj9QSKC0S95xDBnjjmVgzy80qYRZrR/6ifYFvQ09mF+akJAhaj9SE9C+B5ApYL
+        JqFJedJqaIb4ZKWjQNTCldEqJ8JR2w/HtMc/fntBu3Ly09CkXxkjPnXITaVXcb6SagWoZiWGrMi8qJzx
+        NY9rBBuhtlfd/dWSWFGunJ/mvcRMyTcWmFFoCPeIy9f9GpFnN6CETrlOXG+cAQbZ6oxmsN2hgRLlzpRQ
+        ray/4o5naLAkHmZaorPhIoEW4DXhCtjFlVSMTcZheOwOxqZuE3SqOv7qXR6mZlPwuD8OtZXBGHyWjthA
+        B+TEuqOh9irycjyQGH0KN4KPoOD2BUw2FWCJ4MRYqd5XpWcZ6KhWkxDzBD/bKTW4ig5aDFal2s4T8MOi
+        u4gNckZ6shtqqr3VmHOgvw28zp9FckomCgsq0VjXiNWFebxbfYE3Ky+wxvorcF9r6y/jJc3eOgEptUxa
+        EVGUXEgZXNCOCAkw7XCktCDHGC4ELUr8CFCywMdBCQl5L3lPccIyvKgJASuKlRorYM9pUvLxS1RqkErH
+        GrghBOut6vCZI6fVzaGUy8+Sz3Vk1pAvrFno6MPN+htk0EhVRe1Acxz73CwTDOXsxngBWyAJMVJMw1NM
+        zQJ6SmpvkRlrsjEeVriyt83E2x9yWG9zVSv0fCQaz8dk+etdputsBfcle9/F5WT0Pw3H/fshbFMCcMff
+        AT3p11AadpJp9CCd9UW0tF1GZZUXokJtUZVwFdNtpQqw9L4CeJYtkQoaKzFaYrBmOzRt0gzr9Axdc1de
+        Anvho4iNOYLyctZcvl90pAP0Nn2Bbz/7gvU2mmquwoP7PXizvMTQ9LxaB63gLs1qFCwpWlKspGaBpIVx
+        5oibSoky1+puq5mw/3meV0KNMMkqDoEpKziOE6hmuY62tZH3kBCompAxZFkY7wG1nMfpLLxdvVQ6vu4Z
+        hgjvCIScD1VOWYYeZdRKTJd8lmQWZ95oDjxXO9Z1MXpWutvgbf8NioK3oyFSH90JRniSTnfMXnaSbc4E
+        gU4xBU+VWWKaKXqSPe2U9LZ8PFVqgRE+flh8GIMDN1hjc/HydTbGp+IwOBxJFafwWA7h0kETsqyjevok
+        gun4Bh49CkdG7Cl059zEVGMOnhbdRta1o4i/ZY/GJl+UMpVmpp/A7VB71KYEsz3KwZTUVKpXzNUCjdVC
+        d71StXLOTMujzcVq0VwTa274aRv+381wPeQYsrPcERfrCgvDzdjwd1/iq7/9Jax3myKDKn72ZECB1QD+
+        0B5pAUsQrlKwAJbeUWqtqFTUJ4Ck15T0KPXPy1nTd3rI10GYYmXW5hRhClCN8j/ClRtCXi/7aiEen3uO
+        cGV9lsAVVcp7Xj6lNVFh6ntFCixVq1lbdU7dHAJWMojUb62JE0duY7AZQS7foeq6HppvULV3DDEis0DZ
+        knot2NNyW2yFWe5Ps/ZOU7kT2SaYINTJMu4TsLRJA5m7cK/QAdNSf39g27KYiNHJO1hey/gZ8BJr8eBg
+        JB4/vaG+UFaYIu1QAlYeNTLV0gGX30W2vx0Sbhyh+brM9Ml6WeaBwvyzVPJBxIU5oyYrFF0l8XhQlYju
+        kgTeWMl4XJ6ivn3QkR2N8tt+yAg6jaKw8+hKD2EdD2RKvgg/P3oOy51w/eIz2Hz1FXS/WI/vfvk5DrIF
+        rauqYlpe/Hl48k8Br32qYAGs6YU1NVdSoaRYmaG5cuoyW5UAKs1ftS2STmUFhZeTpxoD9iQMzTcJZA20
+        LLTzoOOVtdHa8GYv603zJFN7VxB0JlAp9TrBXiNYGXL0c7ukTJYo/Jy9pHK5OY7zhrNTitXCtWHfbWu8
+        ATdOfYfaCH203TLAYyp3PNUY00zN0znijMUlMx0XWmKG7lhS8ixDhiGlBk+UUt3l5gRsit5MqrjpPJZW
+        PgCVduh1xoe0nImF5RQ8G4lE38BNtDUHoTTWG+MNeXj5uBWLD6nCzgo8ygpHis8hxBBmY+NlptSLdLte
+        hOyJ4lKCLjpLx+uG2NtHcOe2LQJ8rXHh4CZEuurjzhkLFFxzw7206xivz2bdzkNnThTK0+OQm5FFt3wD
+        aXstMbjlS9Rs/hq2GzbCYOM2bPnsGzgePIIRqlgzyPHHgAXu6uIMXi58omABrImPzlnqqgw6yJCgABbQ
+        MpokszhSM6VHlfFgGWXyPe5LZfqoFkfMUeDZAASfu0Y3HKZScCihijO+7hmuAAcI2JO+6iZQRovqFjMl
+        YGVSX7yBarPowPfv3ANrPQMC34AE702oj9ZDW7wB+glVeltxxTN5BMz2Z6aIKZlAJxgCW9LybLElJnMJ
+        WFK2wC02RWeWKe7XeWBhKRVvv5fWiHWYgF+/J+RXdNBLiRgZv4PWtgA0VPijNjkYy3TGq4+asfSwDi8e
+        NGCmrRj1d7xw6/J+JCU4415nAO51BKCu1geVFZ4oLfFg/+qOgjx3ZBNydtZxZOWcRsDJHahkCu7NicBE
+        I8GqFZJFeFaZhpbsOBRkJKOrvRW5CXeQqrsV/Ru/wLKJLq7uNobpVkPs2qSHbVRzkLcvZsaG8e7li58B
+        K+UyBO4aIa9zUK2QgNX0wFrQUpflIoupkRosoEW50sbIWLDMwwpw6VHF8cpIk+wLfNmX9KuOf/I3f9Zb
+        +aK2OOYLdM4CVFPzT6qUL5lDFvjJDSffCT6wywaWeoY8r224aP8dMq9uQVOsIdOYCZ4RnBqJqqRCK9ny
+        lMnABeFK7ZW2qFSTpsVgzZUwXUv9Ld6NvhwTdOTsw8N2Hyo0gwYrl4rNVKoVFS+z151bTMLETDwa6nxR
+        kemL7qI7eN3XhmWVlmW1Rh23DRiuzUZKiCNyc9zRdi8IDx+Hoa8/TM321NTQ/VZ5oqTkHPLzT7EuuyIz
+        8zgS2NNe9aIJu+WF4ao0TDAjjNbnoo+tVW9VLu7VVaCxlrV5YhwlkeHw/uKXKPjib9FprI9z5qYw2qQD
+        w406MCFk3W+2EPIlNQ/8/dqyBi5d9MsP9Ve262zZp8p6YwH8qZI1Pe7Hvlh6X3GyYqpUzWWtPc2ttD0e
+        9jRMhCY3gM8xul9nL8ZFVbvlpxUk1Xs4sK7SbMlrNctqZFhSY9jkJpJvHsjn2u4+CPMdMoOlCyfzrbh4
+        9BskXNqI2mgDtFK5D1ONMCwgq/dgrobgagmxxhpTFVSpGCpxyhVUr+zzeTPlBM46/CBxFzpz9+N+41k8
+        HYjAGs3TGyp3hUA1rVAW9yUtZ2HhRTEe97LfzaJJqmO67mvB8kOGrLFSS3EaMc/2piw1AAWE28Xa3NsX
+        hmfDUWpuuKMzSH3Zu67OR4EuL7/Am0C+JnoSIcGuCA0OQYKvCxrvBqMlJQzNGdHobSjDo+57eNDdheHB
+        QTzpvIfCA9YI//qXCLeyQJq3N9Ju38FeYzP19SLjTfow2qgHna82wuPYcYw97VdK1tReTYu0Oj8tS3bM
+        1QySpEKNgrXxKWA6be5rVa3tf7UhRkjMmfthMVeyDlrg04gxTh48wb/JwnfNpMDH1kszsKI+y+ww9hvv
+        w+4ththnuJVGjnfmifVI8t6AmsgdaIrRQ1f8LjxO2oXRHKZjKnS23JLKtcBMNSFWWfMYgYqhopGaZn2d
+        LdOk406+prPQGQOdgexdb6oBjPe/LsQbOmdJywvsexfYAkntXVhOxfxCIYb6ijDcU4kXfc14yZS80tuE
+        Fw8bscIULWutZNK+Oj0UBbke6sth8jMNT59H4vnoLQyN3ELPwxA0Nfqhvv4SIfuitu4S0/UFlBSfxRVf
+        T6bqAvTfa8BgRyOedTQQZgtGBh5jbOgZ5memMPWgG7cdDuHu5/8Fybv0UZ6bi8GhQfa7Syjjvuk2wt2g
+        pwDL1uBbdhSnz2KSr1eQ5zUKXhUXvcdAs5JDJhNkrFgz6qRV8sfRKvl+rYRAkVEuTXwc8HAU6OyLnaVX
+        ZcjWeY8TQ7YCVDOAogZR+FoBa0+wew2tYLJ5O+yNN8Lv6GbcOvstCkN3oFHqbLQ+uuIM0UdIQ3TBowKP
+        DnimYg+VSaBMy9Nqy5TMVCyPJwt5rMIKPYl02FkOeH4/BtOTuXTJ5Xj3qwKlXFmJIaNUs3TNS6upWBVD
+        tZqCsYl49LbTSffU4t1EP9YG7+NFbwNW1SI6TSzdr1ML5/KzzqGdNXfg2Q0MjUZjcDSK2yj1uKdXfrbB
+        X6m4toZR66vMlwxahIS4ITEuCZ1tLeijWh8/6sPEyAgWpyfVgMVkRysKDu3B+V/8NbwMtqPibiwWZyfw
+        /tUK3q0uqm99XPH0gvFmAwXYmKlas9WH39nzmBoZxFsaL4Ers1rr5Nd19uhbwkp/N/bqm6uZosO7Nb+s
+        I4D/VMmakMcy0vUBtAxdiiLpeiWOUuWSctXWis8VpcprCFVCxo0t+VnGm7YwM2ykWjfhrvdGlIXpKLV2
+        JBuoMeRn6cZ4zhiViXgapHFCnKVa56ptMFvBbfkHJatxZrZAbH2mWXsb4k3Q3xWJhZly/PB9K97/QwVe
+        v8tVXwwbm4zF8JgMZtzC9HwCXjI1y0zR+EwsKgt80FuZgrWnXXj97D5boRYqt0ktpHtBY7XMujtYn4fs
+        u2dovq6q9c1jE8kYn0ylemPVWudH/REELKs8ItHZGapULGm6ulp+vuESMjLcEB8dhbqaOtbaOjzo4ufM
+        L+CffniPmSePUbzXDD3rv0A86+6lfVbo7erA969X8ZpwX68s4h1r7aP7HeoHcgSsyWZ9mDLzmW3ZBRMe
+        8zp1mu76sXrN8twU1vnZb4D++q+wW8dYzfPKr+rIRL/MEMnkgAamNgS6ZjGcZuxZE1LH5UdUtOPPMmMk
+        a7W0j1Wo5xyAGeur0ZaNTNUbEXZmM1KvbkV5FNUWrYueu1QrgT4rMMUIYclI1CTd8STBTpbQVImRqrJU
+        03pThCt1dpI1drryEJaaz2O1ywf3UvdjqD8B776/j1/9upXKLcLKWjohxOA506dAmJqLp3LTVN1984Mm
+        TTdVB7FHjVNjyLIqcplpebmXqqV6l9gSibmaaC9HTvx5NDf6o7snhDfKbczO5WP5BVP3Uh1mZkoxMpKD
+        58+zMPQ8EwP98ejpYY1t8SVoH5Wqq2i8IsN80NnRjZfLS/jh9ZpaYtNcW4202FjEuzqhauu36Fr/GVKs
+        dzOVtxDWSwX39coC/vH9a+SmJROwAY0W4W7dCYstO2HGrek2WdNuiNNHndFYxYzFdL2uJlQH8ec2w373
+        19j+9TfYSRtuoStrsXZjD2HLMh4ZOZLF45oFbAw+1qxWtOFxzc8gSWgWuWlCM+lOqDRNkoZ3bd4BM52v
+        ccH2O8Re2IycwC2ojtyO5nh93Kdx6ks2wXM63NEi9qplMuL0wRmznsr8rWwnWVMnZd5WjBOVKzV2unIf
+        Vu5fwdtnCVTdXQzfT8L77zvxw6+bWGdL2AYlYYQpdIgGSNQrgxivqObX7/Op6hxltO7fi0B3aYICuipg
+        qVgFVwX3xVz1tiA7/gKam/zR2RVEM8UbZiyGCk7C1HQWpqZyMD6eh9npKsxMNmGwv5q9cxZbpCgkxPki
+        Jvo84mPPIJyue/vGz2C20wjnjp9AbFQM7kTHso3KpRmrQl1VHdLc3VHx7eeosj+Ap13MQAQsM0W/ereG
+        /vudOGxmrcAKVAnzD1uLbUawpoBMtxjg/DE3DPb1Yl1PjAGamBrL2ILEU1Gnrb9mn/WZ+hEWY0rfdMdu
+        WOibwoapW37TSgNQ1hoLRD5mOrcV1TJkfPgAlWyza4/6+ovhhg2w1P0KJ/meYW6bke6zGUVXN6MuZDva
+        b+qhN8EAT8UVMwWPZxphItcEU7nGaqxYxo3FFY+Xc1+BJfhqpmKGHBujax4T2A1H8XIgGm9G6YSfpWJu
+        vA4//KoH796XY55wZWx5iM52cpbp+E2WmjR4832JMlhvWJP7H0ejoyyaRqpe9bgrYqYYomKJ+ftVGG8u
+        RU60N6pKL6mfSZIveI/PJGB8OoH7MRiZiGbtvYnGpgB0ddxl2i3DQO99DLC+1lXXEXIR8hkFeQU0WJnY
+        9MXX+O6Xn8Fg/TYcPeSA2krW9eZWDPT1qSXFT3q6UBIRgszAyxh+/JBKXMav379CX1cnju49BHMq1pww
+        zbcZEu6uj4C5b62zm5BN4Wxjj5zkFKx7ctsAj2L08fCWHtrDdVBB0Lk+m3Dz+EbC/hK2hp/BUucz5vsv
+        YfgdY/3X2LlBG+uxixB3bvyGQL/BPr2vqdovcWrP5wg8/h2Srm5HDmEWh2xDVQTd8C19tMUasGUxwpMU
+        IzpiY0zkSX1lKpZhRJmMJ2AZiJgUR0yzNEGY46V8TgFTNevseBFVTjWP0WyNS69bY4fl+wF48zwFL4fS
+        MDtairfv6wgxX114SckzsjLjncAl1PfFePV9IV5/n81eNwFddVGYaKtQcFepWBmCnO+pR2dBItKCL7BF
+        c0KyH+OqE1KC2cdedUB8kAPuBNsh7ro9UuLZ32afRWK8JxJiw1BVUaFaHRmo6Hv4UE3pDT0dYkruZGpv
+        RWtLO+xsDuLbX3yObV9uUCs+fc5eoNEaxou5aRqkF3jDUOPLElTub96/QVNlBWwt9irlmm/TQjVhGKlf
+        R5BjVoQrIQsx3O1cEBUcgHUDN3bgCS/8k9uGeBxF0GG66Aih2WFtrLm8BSV+m1B0ZQvyfLcg25txaRuy
+        fXWQdXkHsgkww28r8vx1kB+wFUUBfP41HZQGbkVV6HbU3dBFPducdjriBwQ7kLgTg1lGGGGMyrLUbCOM
+        MSZYZ8fyCbGY0PKMWWupUBlSZBs0USm1V9K0QJeJewHOY6JyuRFkzLnOCYutHphuPI4W9pzLL2XoMVu5
+        4p6eUDU5/+pd5s/qXXufw2M5eNRD9RbF4dVj9rgCl7FEuANVMkFQqQYzJpvzMVSRjGclsXiUF4GOFH+0
+        J0pcRkOsN/JvB6I4JwNJCQl0y/Xo6uxBT/cD9HQ9QF5mNuqra7CyuIAf3rykG54m9AeICovAl3/zC2z8
+        e3ofmiRZhx4fFYX/SpDvXi7hDWvnG7Vdwq/evkJeahL2GZkRpiEsCVSjXomdMNmoy1qsA2uWVVHuHl0z
+        5Xm8jp1DVEAw/j9+k1Uf+DJqzQAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="hbmg" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAHgAAAAsCAYAAACue3wzAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAJcEhZcwAADsEAAA7BAbiRa+0AAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQfmCQMUDw3xavR+
+        AAAb80lEQVR4XoXcVaxlRdPG8XPHFQnXEC6QEDQEG9zd3R0Gd3cd3N3d3d3d3d3dAyHB+/1+9fHsNJsz
+        zCT19tJevepfT3X12od3ZKmllmqLLbZYm2uuudoaa6zRVltttbb66qvX9iqrrNKWX375ah3rzfm11167
+        bL311msbbrhhteuss06di6255pr/Mvcst9xybdllly1bYYUVyozFOLbbbrs2//zz17GVVlqpxtTf7xlj
+        x45tO+ywQ9tpp53alltu2bbYYos6ttFGG7W11lqrnp2xGv+KK67YTjnllHbOOee0yy67rOzSSy9tV1xx
+        RbXs4osvbhdeeGE7//zzyy644IIyx7QXXXRRXaPNuUsuuaT2zzvvvOr/rLPOqmPXXnttu+mmm6p94IEH
+        2v3339/uvPPO2j/55JPb8ccfX9efcMIJ7cADD2zHHXdcO+yww9ohhxzSjjnmmHbssceWHX300WW2HXev
+        +7TuZSeeeGK1+mD2jcP4RpZYYom2yCKLtDnnnLOcASjnLrroom2BBRZoiy+++KiAA4ptsskmbfPNNy/n
+        rrvuuuMFO2zAAe2ZQIIw33zztdtvv73AGxvIng9a7rO9/fbbt0MPPbQdccQRbe+99679bbbZpiAbg2v6
+        8err4IMPbmeccUbBvfrqq9uVV145aK+66qqC3cMHEyxm2zEwY4F+9tlnt9NOO63uA/HBBx+sd7j++usH
+        /etDoAgwcM8999w6f91111V7+eWXVx/GuP/++7fDDz+8HXnkkWVHHXXUAHKgMsf11Zv79ttvv8G9I9QL
+        8Nxzz13OBHrmmWcum2222cr5vRpiHA0uZ3Jqr6CAmJCBAKxngLvyyiu3eeedt73wwgsVhZ5vTI4PBw3l
+        eklO8eJ77rln22WXXdq2227b1l9//RqbezJ2/csyrgcLUBa4WoC1MU4PbNsJALASAICddNJJtQ045duO
+        6rUCwDWnnnpqO/300wfKT/bQN7Xffffddf9ee+3V9tlnnwrgwKVeACnUPnjaqJYvBLoM4Hl57gilRq2z
+        zjprGzNmTJlt6ZJzOaiHHGf3gDfbbLNSMePgYSCjWVJp1BvVfvPNN+22225r008/fR1zftVVVx3cZwwC
+        ystLV1QM8B577NF23HHHyiisny5ki6WXXrpSm3QK4DXXXFNwqSyQR4Ordd71oIDjPCd6vqwATBTu+gSE
+        VroEoE+tFGwcYLvulltuaffee2+75557Khi8ByWPGzeuQFMmyGBqe+j8IOC1xnjffffVlCBgBoAXWmih
+        Uq0UOcccc7TZZ5+91DScnjlLy9EAm3dB5XBmPpQqHZ8QZICTSqkYAPf++uuv9bKyiQwDsHHkPv1S4267
+        7VbpaPfdd2+77rpr23fffasVbJtuumnbeOONB2MWIKYbwcC5gN14442VIjklFtiBA7btALYPsBZUirGf
+        1Myp+kj6BptyM38mGI0bQPOvPgSB8dx1110F23E1hmsOOuiguiaqjarBdlzNIuO5D1iAjUOwDAAvvPDC
+        NfeCCi7IoP8XYAoBkjOBCWAD4+QoNGBiAdsbpXo+p/3xxx81UEAEHMDDadqz8ywvqJXaRLKAk1WMyz0s
+        ChYU0ipAAcwUP2l7yNrMo7GkVeBsP/zww+VUoDma8ylP4B1wwAEFAlxFlLFSoyATAJ4hcM4888wyga0v
+        5/nUO3ovwPUpQBjlSuOULpgEhvukeue9i77+oWDWA3Yc4EAdH2Bq2nrrrcu22mqrMgOTJp0H8L/g6k+x
+        Ncsss7R33nmn+ffQQw8VENOE9J1Ac32eTaECyXM8kzI40DGAk0UyZs+QdcyDwPRwo2AFD7MdyFSYdA2s
+        NqlVvUA5ALqecvTpGvO9aQMIaRkM6VdfN998cwHxnqrsO+64o/qT9pNezaGCwTsJFgUYxVKwvoAXcJSq
+        L620L4vdeuut/wa84IILDgAzx6W2gO1Bc3LmYIUVp6aS7UFzvjl5GCpzP1DUScFA/vLLL+3rr7+uwVk2
+        CbQUWlSYewOYSj1fQHkxWWSDDTao8/o3ZmMNYH1KexRCwTfccEPBBBkgbbaj3qRqLZVSHmDPP/98gQBN
+        +9RTT7XHH3+8nOsamUJqpmIt06fzYABJ/SB7X5W38SS9UqV+ZAC+BFS65mugXes+BrB+Bbl0H+CDKlqK
+        BlhKVL2yZZZZ5l8pmnFaAAFMwUCC20PmdEpKVRs4uRcE21KwABOxn376aXv66afbY489VpFrTOALtB6w
+        5wKsf4BVz9Iv4PpN38OAl1xyyXICZVAhyAHMko6BSAtslAwwoO4Dgkq1zz77bHvmmWfKsRStL+8DjlSu
+        aHQdGFrXMfO2NpBAB4Y98sgjBRkw/fApX5sCkgFyr+uNzxQlTTtegKl0NMAKHIXPcIqO9QqmGM5mSc+Z
+        B5nzrg+cwNW3YNBS6rvvvttefvnl9tJLL1XLeaJexAqC8QEG1cuDHPUOA3avQKFgaVO64yjOA1haDdTx
+        AQ5kc5y0GkWD+9xzz5V6FVvSs7TMF5YulJmPHRwfAPZBfOKJJ0r9TGC7XkDY1ic/KLCIyLMFUOAygN1D
+        3ZaMwCYLDABnDlboWCaZ+wBOcdPD7RXMMg9TEqenqs5c2Cs49zAOf/PNN9tXX31VFTCo0t4HH3xQSyUv
+        LA1Jh4BRsT4A0yewnuU5nOmZjgew64yV5bh5nYI5g7PMZxQJSj48UHGvZCCB1VIlhwMmA0ivTz75ZEGm
+        RgEjkyiC9CEFC9jAT2AA4/jrr79ePtCHzOV6qd2SyjXuA4oQ9GtMPdyYIBXg3iNzOKsUnTmYiq2HwWX9
+        R4YebgAHWFQMcNI1x0fFjrumB6xfVSWQ/n3++ef1Mh9++GH74osv2nfffVeKVnSJZukaYPfqx/OATbYA
+        WCvYgPS8AHZ9pgxKVrAAnHkxxrGARtF9G9ACwnioTsuZtsHhXPO7AACbOt96662adsBUSLlWYSaFv/ba
+        axXU9qlQXQCm5xmPjAG8IBJY0i/1CpIersAxLlnD1OGYfgYKZuAyoH3VkqIBlhonBDgOpZIYJVMYAz1g
+        cr1nctCff/5ZgP377bff2g8//FDQP/nkk/b+++8XcE5RqPSA9UmxwAJtG2DjYMMKzvgUcgBbdkh7Upr5
+        jUPtmy+pFVAQ+pRNka4Hj2IBc06mAUEfUr9MIFjNyW+//XYBFqyuSSGm2pXeQQBMn465XyAponwREziA
+        AWvtrOhKqteCa1UgcLVStT4z3w8AZx7WqqQpWJHFIQHbA+Y8zg4wRj0xzgQBaNvDAaHY4YD8++uvv/7e
+        +v9/IEvVIHOMFwfYvfrIfA8qZUph9j0bTNcEsPtMB9IzR5iDrSmBlUpBi4rzAcF6HNCADWTrXM578cUX
+        S12OSbGUDoCsJEgURxT6yiuvVJDKRN6DwpwzD1M7YODp0zHj0o8M4wuZLACkc1RsKgMRPIWWaUbqtoKQ
+        AYBP0eW+AWAWwFGxdJ3iZjTAPbBhyFFSnB3ATD/aN95442+crf3+++/1Bcs/qjYvc4oUZh4G0HPzPKkf
+        UBnCOSk8gJ3XfwB7B4AFlfPmYJ//gIx6Qc63XvtSnvmUmgGWLimLEwGkQg60T2VACWSVulaaNp8KYueB
+        olR96cc7gQOoZ5nPBZFxeR/AZBnZQGBYZ6sVZLJ8zwZbQAlYgalf18oGsZqDMw8nTfcqNmAKGAYc68HF
+        sbGA1WZbXypZc+JHH31UQKUwc/DPP/9caVqr+OAcKUjq9Kz0k/SctKy4YFJ1r15mzIpF7yFwqd16MoCj
+        YNvUmWMBzalSZdTsONjgUQln+wKlKKI6QIzbvCodg2tO5Xz36UN/0rHrTVNSddbwlpnE5T0cA526falz
+        vWsFsh9WQDdWwW0c+vI8haoxqMJHfA4M4KRpxhkAq6qH18LDkDmS0+NsRRWlUE4CxH32pX39SrEi+scf
+        f6wXV4xIy8AamC86nCCKBY5nJEOkiOMQz/PyAkafHJPrmWIOYAqWkXbeeeeKfOqJaqNg1br9HAOTurQK
+        MGmbeoE1RpClScEiTbqHqjkZXCmcxdnSs0JMMFAe1TtuvsWB8nGYbLLJ2hRTTFFCMBa1gP6Nz/MFovE7
+        B7osIJ17jimBvfrqq+3RRx9tI9IWsDoGulexNbFflWz/l4qZT2fSh4coPqQgc4YBSDnAzjPPPOVkCuNQ
+        kUwholQqlvakPJD0SfGCwjMdY6pnaTlwAfNs+4IM3GQLfSgUAWaClirMcQHHSVrGgcy28Ul7+cCfdApu
+        D03q9R4CzD3gWhM7LkWaD71XzHybvhSP5syk2kxF3neSSSZpk08+eVXGgl3LV8Yr8AUJ0NTsmAyhUlf8
+        MSrW94jIjoK1UXGgZ01MiVFy1MEC2MAUDcP/fvrpp3KIFwJAlIsu86ylUD6tSTHmEn0KAs+ivh6uCKde
+        qVhakqYAo2CKdj5pHOCoF2QB5h3yAwDAgPSQ0zoeVbsukH20AIgDvZP5jjkm0wAtAHwlM05+sQ10D1jB
+        KFUD7JwULiAIwvsLRCr2656x6ls6zjwsm9iWOZynXv3qz7gEmCJQ4TfCAapLKSLmN9mkbrBTUUuBqmrn
+        OIvjohDOVIy99957VREDmCUQyOYHKcl8a5611jXvOuZeYzDvCypwGQdRJLhSs+fnowblSlvWhpTMoVEv
+        ExgZHxM0gkBASYlJwSDGst+3wDL77pWSM/9Sp2zFkZTvXYxl6qmnbhNPPHGbaKKJ6tmu5XwpE2QZSx/J
+        AFpTE8CTTjppm2mmmSp78okA1qdnCBZgiUGq5gfiMEdTr6LVVEdA0rSMMMKRoOkMWCnbtvwfyOZhEz8Q
+        nCOiOdhcG1Ux6dQD/fOTH1MZiyrRLxI5xQA8XPoGUQCJWs81FSRTRLngZo6XCkGlRC+vKJGeXTOsXs71
+        bnkv10t1HEWtLHAZ6FFufwxo7009gHAoAw4s86ogULwlo3mOT75TTjllpVQQGcBgawHXn1ZRpj8+mHHG
+        GdsMM8xQPvCephTLJMo3JkWdYJOmqR/Yzz77rL4dfPzxxyUyxxRkI1THqeAELOOQKJr5Tk0FgSwlyPMW
+        8jpUMIku4EHNuhZk10krBpUUb2oAVb+em1Sq/ygXtJgA6uFGvaYGgdbD9U6Bq6UGKoh6wejTcm8B61zg
+        cqx7BCflcSrAfr0R0K6XLvlR8DimoJKNpplmmso6ii+AeyVrA9lxfZqPvYNgFDDGLFgcJyxQ1SnqDgz0
+        KysCGwto4xwAZpzL8YzTRX7StZaaAZG2DcIkr9iw0DdASwTRRZ3SM/CpNA3OvG5e8VOkfgSSVA8uo1zw
+        A1d20FJv4HpxL2fepV7gXeMeY3J/wApamcf9gkKNAFSqZfBSWPXFlW1q1XKulOjjBBhUJpA5Vkp1Tn0B
+        Bp855n09f6qppiq/8Sd4oDKgzZP5qhXQ5mMpHzjBJEj4LWPnb/0DDLxpj3gC1LKzb3EZCdwYJxucOTdq
+        jnmBgBedFBjYCiTOoRAFkMF7KdUdKNIwJblPH14aXAYIZesnaTnfts271q6A6gdksKkiy7HAZRm/Pn1u
+        dUxWoQBjM0ZwwYtqbaeAsc2RqlpTiPUvmFTGqNZ5MFwrRbtX/6YK87Cvb4JKcE033XT17gEcmBQv+B3T
+        r+3eckzfYGbdnmWSoDKWfAoFNAZwIBdgThkGTc1UNQyXga+VxnuVg61Q8pcZnAyCtOmYPpIdUqCBkJTs
+        uijXfaAyqZViRTFQ4I79+weMYbiCRJ/69/OjIKFyKuSQqJejGLgcyGHZdtycJxOBwtE9BKqSJgGmJNUw
+        xTpmPe+4zOV62UTRJPgdj3oBptLsxwJXZZ5t4+oB2xd4KmcfgdQ3CqyA1fo0alv7LwUPG/hJeQz0KA8s
+        sNP2FpVm3/WZZ6VOZnrghMyfoKkMgQWSai2FpD/qNd8GrvTdwxUkgkWwUY61svsz7/brXgY0xVKEz4pS
+        LSc6J01yvmknQJJCKZpzbStiBAUgCinzrxRu2rKu95nTRwqg9NMD1V+eIZDUKLYDmMkcUrQCVd9qAsHo
+        vQSNwGWuEVB9qo6NcOxoYGNUwcDgQLAnZAHYb/emX0ACNz/9Ba4UT7V5CQVVD5dy3Re4TCAqAtUJWUa5
+        F7TMq4HKSf228/kVJzA5Ox8NqAQUTs/XLPsqW0o3L7oGbNsB1wdJzDHX9n2ZhqRbz+0V7AOHAPcePo4Y
+        M194p3y7NmZZhZqH4ZaCqYAFYsD224Hc23BxxnqIPWzn0k+geiawoAWsVkoFh2rNa5QrTVNk/yFDP1Gu
+        5/hKJju4P0uLfI7sQQZ0UrO51nEOAiOArQoUVlqKVBQBpIAE1TEgKJT6OVralSlcA6L+EhzMNqgBJht4
+        lnOByhyT7mUfS0sKNb3wCxVblimw9G/cxmj928MdAI7DkvJsc1ogBqhjsRzLcc7urVcW02dfOKl8A5Yp
+        TpKSqRZYrReiZtcaX/rSei7VSsnW6fp2fe8Uzkg6BjSqjXGydBulcWx+e6VOc6s06bhrAAfUPRQnkKjJ
+        vr5UujIPyPoB1H2x9JPqOccyv2vtW97kPYzTO/CR4LUEo1xjBND6V5E1DJf5uXUEJGBVfZzEkWAEPGAB
+        28Prt12nj3yUYPrSZ4DGAhZQg05KplSRHbiOuSY/IASs5wo8arXsMr+7TuoyV3G4aM98CyqlJi2nBQF0
+        AONsAC31KJAy4nDOt2zhWGmTkz3PNrAqe31Stta+1JvCSvBoo2Sm3347kD0jn2CTcWxbWvoAYtwCgOKB
+        zbwbA/ZfRRaHcWBgcKqUyFLQBBzj8Jh953ug7o/1cFMd55cg8yrVASOlilr7UrJr9OUZggdYY5XyFWvg
+        Sv0UI52bQ6m2B8soAEjHwLWv5TwmTXI+B1MlhVIfxzvGpECOZwonz8pfY7je2KlZsSa4VLmgpNIFQz/6
+        TNoO8ASPH/EVanzCp/ygOOQby1Fwp5122gpo87wpAtDRAAduKZjTskyiUp0DQxVUxNmggEN9zgHZWw83
+        gLU5L1AA049+s/RJERWwnkfdrtVHDzZzuhe0lnacUznAEkg6DtBAZQE6DN6++dd9mX8pWFqmvAAGl2Is
+        hygWQFA5GCgFjqwTwBStT22qeMoWHOnHd2VZQms+NT5BQ52KJ+NzH39gYwmqgPTp0ydMQe7+CQEeKFgn
+        gSxlS4WgcTQQUgYABuyhogwsKmSBz9zjfG+ApngS2QYfsFKdcwkiwUDtAkPA9QWbtbSXFYTupZwUSb1C
+        AzVtFMxxaQOY80FMqqS2Pi2DAI5ljHuo1tcjcF1H0QJVWlZseZ7+jUkwyCrgeW9+9I58zVd8mYpYcHme
+        zEDJijHjc4/35Hvvbgnoa6CMq/Ab7SMHsD62/EPBvQU0BRlQ4GRuACUD9mIBD6Q2IKMwBohUGrDOu08A
+        UC3AXhpYAD0fVGmYar2ctbVrAtfakNM5lAUmsPZHA2zfPVQPCKcmXWZepGBr0/wdlOukW8URp4Lrd1/X
+        eYb38F4+fLA8D2BjZCBL3dKu93NMcHiOADMOhRNFAyyQPJNf+E9/sqJPvPmYxJ/+7kuhFcBRLrgDwIHc
+        w04FLRWaY4EGA2yqDmCwRTCYtpltx2I5B7z7U2CBlTkfWJnDMz0fWB9KrGsBtu8+juQszvPSHOwrkra3
+        gNXmvOupgnMpUoElNUvFgUvBnG4Zks+Clix+X5WW89cazAcR46FCYAGzXJIV8jxp13kVMQNLQAs2zwAy
+        xZ3pAWStnw8Flg9E/KRCJzifey0JrRx8rQPZO/j5dRhuAaaS8am4N46XFkSf9J05VmsAnC8AtF4gqgRS
+        2g5M96Zw0pftVMaeazwKKGABlqKlbarlTAqgQNBiUS0YsYDOcYo1L5onpVxQKRfQfGu2TU2288MJiFKy
+        Dx6BqxUMnitYzM3gSueMAgVHxiVdG7cxCHJKBlo17lrfrz1HRmB+OjQG8PidHz3Huwp2kBklm5f52Bgp
+        uYcsTdef7HBkPkaMDzIAUTXL0inLJ7DA7osrMFOBB6ogcb37ApUZQ75EgUrNgiJpnlMogbM4rrcectJ1
+        wFINJZnbVMwAApS0rGKWHsG1HQWDng8cgRvA7gXf/AqOfhVegoL5yw7q64NQ4UXNMpmA0L9nAar1DFnC
+        jweeKxD4jGgED4DmW9uqanBjflSRGX2TDuR/AM78ZvkxDHoY8LAFOAOOZb3aWx8QrtW3ZymcpBvjcE5A
+        ZOmjOgUIWM4BF7geKLMd1Wrtuw8ADgeQA8GhDPvSIuNoBVU+cADF4b4M+asIUHvA5l/zpGyQHxtUtIFr
+        H2BzNxUHcMZnWrMviDxXsHhOfhWSbr07JvxE4c5Jwc5rBQmfgRsla9VDvoG7DtwC7Kes/BrEyVKAjwgB
+        3EMettEgsz4AYv19+vQ8gwKYqsf+n1pFLbWab0AFKGCpkHGONBvHgcmcSxGlAJOGzaucl8+MlkMgAsKk
+        RcBZfgYEiZP81Yn7+nlX6x5jA9B8a/3qmIJMn+ZrAeCc6tgY+0CUiUwxlldZklGb/6KDgk1Fshb1qk2c
+        //LLL2s5xPyZkwCU7YAFWuHFHFPoCkj3+K8p6kuWyZrsA1qb+a8HEziUx5zvlzExAcL6Y7nO/Gpg+qdW
+        84uCLWlYEdRD7avkpF6OitNAkQ451DrTXMV5ihSQgOEkAMADAZTMuxREvfkESKEBOwxXP/qXnqVmz5Hy
+        nWccL4j0z8zHw+naO/lDOc9X9foDfz8vgk3xAKvKs8roAbv+22+/rQIRzMDFLsa/ah3vKV2PkDv1mPtM
+        2FTlQ4J9oJO681Mf6/ez3Z+PBS6VJpUArWgyt3iJVMXAqowDNABtD0NOutNyCkdyWNJs/pMRTpcKvaxr
+        nOMwapYKtQCbn6VWQJOOAzdmP3CtUQULwKmEY7KGvo1HwIFL8bISk0YtcQhJcAtk76dP04Ox8gf/CHhp
+        HGBw/YfxgpJPh8Eyv8fj5pzCy/uP6ETUmPeApiyK9u1ThOQmoJXsgdcDDcgcd60HWpQDK+1HrYoBKcj8
+        6kXy5Yd50R4mgEm9ox3TUh7VAEdNgPlTFUDABQJciopiAQOXAxRIUqpjvXJtJ7WDJasIKiAEiv7AlRmA
+        1g/4AsW5BJFzAohRsznVhwpfpEyPpidQvYPsIesIEoEr4I1LWvYfBYCtTglMNhpgpg6i9BHRlUU4NYkw
+        0aMCBsaN1l0qtTFjxlQbA9A5A6VOkSNFUKzCClAfPgSPTCENmx8tF6ihhxpo2Qcyc2t/jYjv52SAQQxg
+        aVLFGedynmIq61xQOdI2EOC6F0zqBde9QPGNgodfGAVmbS/7CFTv47p8LqVC/VFzIOtbdvE8YzEt+r+I
+        8h8VyJL8I+OYM/PrUD5cSM3+fty7mBb5eBhs4Mq8jEjN38Y04n8MUIq0rfrMLzoqPopjJm/g87UqX66s
+        e523rxUg+RASZ+gv86vCSWQyoALZNsCB51hUG7hRbW9UlY8M1GGeSxqmNHOl7WH1Am7ONXdbd0a5AkDB
+        RS22VdzmR0HkGVShwBJYnmVMnkFx1JwgMwZFFjCWLfmP6TxXcPtrS3//bC4F2Tt+//33A8AxyvXMiC3K
+        jcmQMq2UT7la2dR3iHHjxrX/AVnctfIU4TeKAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="Icon_th185" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAA1lSURBVFhHLZd3eBbVtsYHBEQUFBtwjgVED3LlWB5F9KAIUlRQsCAg0rlggqAYhBCIQEgCgZAE
+        kphGElJJ74H08iVfeu/Jl957Ib0Av7PIvX+sZ82emT3r3e+qo0ABkCuSwTgRou+KBPEQd9GeIt4iPiIe
+        Iv6TMibP7su9+5P3XET+bw13RAKYwFX0o70+jI/4io6H+8GiQ0TCRVQilTBaj/JgIkMW2VTXuZBdaEJG
+        4Tlyy86iqb9ISYUexSWnqK+9SEWZPiUlZymtPI+m8RLVXVfJqTpNoeZPapoMqW22JL/8ElklZ8gpkz1t
+        l8kt0KO8yIKqIhuKM0xoqbKhpvQa5QWWPBiSQ4/VIgxkoVJdwshkPXoXlvOAMNQ5J6luvEJ3nw19vbY0
+        1F4hLuow/r7bCAr9GXW2Ds0D1vQ/dBM2fOnscaG+2YWGNlfZHyJs+JKccZxvNk/hhTkKs6cobFnzPHd9
+        dGmrdqe91pvOhmgYKkGZGI2lrNSG15cotHa7UVR5lZLqK/9PVQj35OOpiSfxctlOVupZenpu0TfkyoBQ
+        PCzuGJ4IE6OJ8m4a4w/iaOlyYlQAjD/0IzlJnw2fzuXrzxYS429OW0U493vj6W0KIjf5bwGQiTLYH0ht
+        jR2GxiupqrOiptlGThVM/7AfHR3ueLrswdNpD3Hhp5gYfAQqkXuDXrT1OdEr/h1/qGJ0LIXevlh5lkFd
+        swMDo7fp6HYiJdkAg9PfEhdsC30amosjadMEUFNwk8o8ATAWjzI65Et+riFp6WcZGvWltslOguhRMKoJ
+        CdTB1/0YRRk2DLVLcD5IY2TgDvX1jnT0ujMw9iioshgYTKK01J26ei/SMi/S2nGT/gFPWppcsbtxCE1e
+        qBhWCQPR9NSFEOX/O3VFZox0OKP0djqgKbssp3Vg/H4QDc2ODI2EExd7EZeb2qhjrtPzyF8DWYI4R0A8
+        Ctpkeu8FkJ59md6Bu/QPxlJd7YUq8bLs00NTYcHERADdXR7ERhpQlO1Cc+Vd2qvDyEu+irnBSsoyT0oW
+        OKG0NVyjpd6M254/MDYu9NTZMzISRXSEEVr7V2B6fg/5Kg/ud0rUDhVx/14qgz3RNDeJwWRDPLy0KS13
+        pr01DG+P47g7H+ZOsA4jg4EMDwSQmmKM9+2jlOQ7ExnyF15O+/B32UZNvi79DRcFQJ0J1WUG3A3dx8iQ
+        NwUF10hKukxYkAHmxgcpTgukLi+GrooUipN8xX8SQCkO1FV5EXFXn9i4C7i6auNoq43+ia85svc/WF/d
+        S225CyWF17np+CPRcbpYW29HFW9IqM8xQjzkeZ64vPEySk3RGZqrjJkYdufhRCAd7beJizHEQP978lK8
+        6arOhN56usqyaClU0aFJpDDVnSDvs5MsaSrc2b1zKVp7PmHnpg94VlH4csVCClIcuRuii6PzNhJTzpKo
+        NpZ0v4Krw2Gi/E5Qk21Id7kAqC8+S13JOfFrOP2ShvfHIyjItcP4/HZaKhMpT4vEzcyIjFA/mnPVAiKR
+        3AR33O1OUF3qT1VZIAGeRmTH+mH4mzbzlKksfnImQc7GZKgs8fXXJiXbWAqbF8GhRjhYHScv0Z6mPFta
+        881RGor1qc4/w/1+V4b7JLf7Q2is9cHPXR+vmxdZOm/W5Kl2rV1NU1YKdNfRU5VKVtwtGisiqC+PprM2
+        kwQ/D96b909eVWaz6Z33sTfWIcBDj4iY0yRJsCakWWNjf4owPxthUUVroRv16QKgRP0bzaWGjPU4CwsR
+        aEqsyUm3xMb8F47u24DuoR3o7t/Fwsen421xjY6iTJoLEmktS5hMrYYSNQ+7m6hJTeHb91bw0YsL0frq
+        K9wtThHqq8edmD9RCQDH22dwcjWhrb5MXFojDLigSTJGyYvVprXUmM6a6/S13SIyTIfwID2OHPgP507s
+        IP2uNzvXfcbL06aif2A/D1tqxXeS+/U59NXm0F6eKwFaTG9xISoXF+IdHIhyMMfR5CB/m39PaNSvpBaZ
+        YuchcZAaCg9HYbydxrybFMefRsmO1KIh/4Lk5V9UFlwhxP9XCZ4z6Ol8SaiXKZr0KJY+N5sls5/ixI7t
+        DGhKqE2PpyLlDhWpEbSX5tGSn0VnXoqU9jTorGBUE42v3V6CfPcSlXyE5CJjHLz/Ij0vlrGhbhiupanY
+        kpzo/0VJlpdaC4wlvYzobXEiKeYsqmgj/N11JQvcGO8tJtLbjq/efwd/y78ZKNUwWF5KQ3YcNRkRjDWU
+        01mQTldBkjxLpL8wnHsVfvi478bVaysJOacJVRtg6vQXgZGBpCfFM9ySR2OBGeqQbSgZ3gdpTL8ggXiR
+        /o5b5Eq6ZKuukhBmQLi/Pi3NUnprY6WEljGoaaYrvZrO1GI68lXUZwSR6mVN+N9GdBcl0VcufaE6hoJk
+        c264/oCLuDe+4AYWrnqYeTph7xXELWsHiZc7NGWbkx22FyXBZhu9eddo11xnpNuLylwrsuNNiAnQxdlm
+        D6mZZpRX+VFTnExHQRkTxe3URahR3baiINKelpQAKqNu01OqZrw1n4I4e1xs9uMXcYyobCPsPf7EytmE
+        EHU2VW1jNGkaxU2VdOZaE2W3ESXVdic9aVdR+f1KuKc2AY5a+NoeQh16lnCfo7i67ZMm48O9lgxBHkt3
+        WhZjBflCeQS9JUJ3fiQTmnT6K7MoTw/FQ1ItVqpoqRQdy3MbObRzBeHBHpRXdtDZK+4fmpB+0kFPtg1x
+        N75CSTL7nq6ES8S5HSXW5xSJfn/hYbGXlNDT4oY/MDVdh6PjbgpSHbjfLI2oJpeJshRGaxMZqYtnojKZ
+        IVnnxwRwUfcgWoc3kBVrQ6KZFj8vmsrr0xSMdH4nN0nST2yPSbJzv4XRIhfU5t+gRJ5by4DKlOYUWwnO
+        uzRmu+Nssp07rgeID5UqliLl1OkHbtn+RHLwOTL9DIm+qUuk+zlSQq4TZnOeQKuLRN62J9T/JuZ2+lzW
+        28Xxhc/w57ynWf3UDNa89ibWelaT1ofEft9gJUPZTiReWC8A9D9lNMWMwSIfRmpjUAdewvT0ekLd9lCa
+        c47EpN9RqXUICzxIqOd+4jyO4Gy8lYvSeOyuHiUz1ImeklQ0GQnExwZyNy2IEHcLbn3+OVdfeYOdry7m
+        kwVvsPnfGwlxiaRbaHhAB20xN4gXO0rwyXcZVpswVhFEt4xMIa6n8JWWmpeqT3OjOUkZOsSojxISuovo
+        sAMkBmtha7IZE8PdsnagrURFmUr6fGKktN4YsmqycLM1xWDJu5i/sZwdi5bx+eL3eO+ZZWxf/zOBcZEy
+        cXfSGWtH/IlNKEEn32Ig+SJ9xZ5UZLri5XyM3PRrtDbZUt9kjjrvDIk5p1BnHpcueYgQr5/wdNzHBcN9
+        bNu2lmfFx1pbv6Q0NZGDe3bwxPwneebxKaxXZhB3+DTBl26w5aP1fLroYz5c/CHLP/2YyDtu9EtDu3NE
+        siBI902h40/qpP77uv5OeakTza230dTcoLHTnrxaAVFkQESCVDT1cVSxf2BlsZ1VXyzjiaenwkg782co
+        7N+yifmzn2T0wagUtBZWTH8a480/y9TzkCDPAFYu/Zg1767i9VdfZuPHy+iK8MBj9wYUi60zIf8KCd5H
+        yUszp7HRkzqZ5Tp6vGVAdZI6biZyjfySK6RJX0+K1sPTVYf5i2aTXZRFV0MZr8yawkvSKzrKKpghnXPR
+        C/MpDI9l2TPzJPAmGB4e5aO3PmCu8jgvPTGLxY8pGHy5CvutX6DcOfEeLcHHKY3RlyJxk9pqR4ZHImhp
+        8aWq2oOqBj8JQjMSos8T4X+C9MjLuNvrsuKTd3hiziw0OSk8L0b/KVKToOaVGU/x+twXqcjI5qnp04WR
+        Marqq1kwZy6F0QnUxyeR7+LO2mnTsN78NYrT5pch4SrUudFX48RwVwAnjy3n5WcV5gq1T4qPN697hSXP
+        K/zwn2d5bbrCpuULWfDCbB4To+Gujrw7dzbaa9byL+Ux0l39iHL04Gm51jp0kI6+NrS0D/Di49PI9PHj
+        bWUaH8rQYrByPdYbt6L4fvE2hFpI4dhGiOVWfCx3sFj+Zqz09hLhaIqLySleEyC39A7ylhiMvXaeJaLf
+        eWk+/5DJJ9j6Oi89WitTiDE0EwMzWChrf0sbnpmqsPen71j22gJekHtBhoZE6huRet6c1eIOi1XSjCLX
+        rZb/SCvGIq+Q56ZF5u0T7F25gHfEqOXhX/gf+a169EEX7YN4//oLppu+YdXjs9D6cj3z5f71Y0dYOglA
+        wXXvkUn9hojZgSMyHU0Rd8zijTnTeHfmFAGnsFaZic1XP/OxsGC1cjeK378+wmfFchmGrjMYc4nOKHPq
+        gmxZM3MOuiu/mTzt6see5NJnG/hErm99u5sVouvCQ3hZ9G+fr+aT6TMx/HQDH8j6yrrvuL5l1yRbems3
+        8g/ROt+sm/zOpbVrsduyg7/X/8Q6Gd2s3pduGPz6ZwQtX4np8ue49MULXPluKXqr32b9tLlC04t8O2cR
+        W2bNF78p7Jz+PCtF75r7Cn+sWsnnC+byb1mvnjELgxVr+HHGc5PvfSTy9dS5nP/sC1Y/9zSvyfrHec9O
+        An8Ecq3Qv0d5k6tLtvFfSB1XREYqPzIAAAAASUVORK5CYII=
 </value>
   </data>
 </root>

--- a/Touhou Launcher/Properties/Settings.Designer.cs
+++ b/Touhou Launcher/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Touhou_Launcher.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
     public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Touhou Launcher/Resources_en.Designer.cs
+++ b/Touhou Launcher/Resources_en.Designer.cs
@@ -683,6 +683,33 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Gouyoku Ibun.
+        /// </summary>
+        public static string GI {
+            get {
+                return ResourceManager.GetString("GI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to GI.
+        /// </summary>
+        public static string GIShort {
+            get {
+                return ResourceManager.GetString("GIShort", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Touhou 17.5: Gouyoku Ibun.
+        /// </summary>
+        public static string GITitle {
+            get {
+                return ResourceManager.GetString("GITitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hard Disk Image Files.
         /// </summary>
         public static string hdiFilter {

--- a/Touhou Launcher/Resources_en.Designer.cs
+++ b/Touhou Launcher/Resources_en.Designer.cs
@@ -719,6 +719,33 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 100th Black Market.
+        /// </summary>
+        public static string HBM {
+            get {
+                return ResourceManager.GetString("HBM", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 100BM.
+        /// </summary>
+        public static string HBMShort {
+            get {
+                return ResourceManager.GetString("HBMShort", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Touhou 18.5: 100th Black Market.
+        /// </summary>
+        public static string HBMTitle {
+            get {
+                return ResourceManager.GetString("HBMTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hard Disk Image Files.
         /// </summary>
         public static string hdiFilter {

--- a/Touhou Launcher/Resources_en.Designer.cs
+++ b/Touhou Launcher/Resources_en.Designer.cs
@@ -611,15 +611,6 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fighting Games.
-        /// </summary>
-        public static string fightingGroup {
-            get {
-                return ResourceManager.GetString("fightingGroup", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Game Configuration: .
         /// </summary>
         public static string gameConfiguration {
@@ -1232,15 +1223,6 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Other Games.
-        /// </summary>
-        public static string otherGroup {
-            get {
-                return ResourceManager.GetString("otherGroup", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Patch.
         /// </summary>
         public static string patchColumn {
@@ -1264,6 +1246,15 @@ namespace Touhou_Launcher {
         public static string pathColumn {
             get {
                 return ResourceManager.GetString("pathColumn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PC-98 Games.
+        /// </summary>
+        public static string pc98Group {
+            get {
+                return ResourceManager.GetString("pc98Group", resourceCulture);
             }
         }
         
@@ -1586,6 +1577,15 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Spinoffs.
+        /// </summary>
+        public static string spinoffGroup {
+            get {
+                return ResourceManager.GetString("spinoffGroup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Shoot the Bullet.
         /// </summary>
         public static string StB {
@@ -1636,6 +1636,15 @@ namespace Touhou_Launcher {
         public static string SWRTitle {
             get {
                 return ResourceManager.GetString("SWRTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Twilight Frontier Games.
+        /// </summary>
+        public static string tasofroGroup {
+            get {
+                return ResourceManager.GetString("tasofroGroup", resourceCulture);
             }
         }
         

--- a/Touhou Launcher/Resources_en.Designer.cs
+++ b/Touhou Launcher/Resources_en.Designer.cs
@@ -529,7 +529,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot find game.
+        ///   Looks up a localized string similar to Cannot find game. Please check the path in the right click menu..
         /// </summary>
         public static string errorGameNotFound {
             get {
@@ -543,6 +543,15 @@ namespace Touhou_Launcher {
         public static string errorInvalidNP2INI {
             get {
                 return ResourceManager.GetString("errorInvalidNP2INI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No Category Selected.
+        /// </summary>
+        public static string errorNoCategorySelected {
+            get {
+                return ResourceManager.GetString("errorNoCategorySelected", resourceCulture);
             }
         }
         

--- a/Touhou Launcher/Resources_en.resx
+++ b/Touhou Launcher/Resources_en.resx
@@ -733,4 +733,13 @@ random game option:</value>
   <data name="errorNoCategorySelected" xml:space="preserve">
     <value>No Category Selected</value>
   </data>
+  <data name="HBM" xml:space="preserve">
+    <value>100th Black Market</value>
+  </data>
+  <data name="HBMShort" xml:space="preserve">
+    <value>100BM</value>
+  </data>
+  <data name="HBMTitle" xml:space="preserve">
+    <value>Touhou 18.5: 100th Black Market</value>
+  </data>
 </root>

--- a/Touhou Launcher/Resources_en.resx
+++ b/Touhou Launcher/Resources_en.resx
@@ -721,4 +721,13 @@ random game option:</value>
   <data name="UMTitle" xml:space="preserve">
     <value>Touhou 18: Unconnected Marketeers</value>
   </data>
+  <data name="GI" xml:space="preserve">
+    <value>Gouyoku Ibun</value>
+  </data>
+  <data name="GIShort" xml:space="preserve">
+    <value>GI</value>
+  </data>
+  <data name="GITitle" xml:space="preserve">
+    <value>Touhou 17.5: Gouyoku Ibun</value>
+  </data>
 </root>

--- a/Touhou Launcher/Resources_en.resx
+++ b/Touhou Launcher/Resources_en.resx
@@ -591,7 +591,7 @@ random game option:</value>
     <value>Neko Project II's configuration ini is not valid.</value>
   </data>
   <data name="errorGameNotFound" xml:space="preserve">
-    <value>Cannot find game</value>
+    <value>Cannot find game. Please check the path in the right click menu.</value>
   </data>
   <data name="replayFilter" xml:space="preserve">
     <value>Replay Files</value>
@@ -729,5 +729,8 @@ random game option:</value>
   </data>
   <data name="GITitle" xml:space="preserve">
     <value>Touhou 17.5: Gouyoku Ibun</value>
+  </data>
+  <data name="errorNoCategorySelected" xml:space="preserve">
+    <value>No Category Selected</value>
   </data>
 </root>

--- a/Touhou Launcher/Resources_en.resx
+++ b/Touhou Launcher/Resources_en.resx
@@ -288,14 +288,14 @@
   <data name="Title" xml:space="preserve">
     <value>Touhou Launcher</value>
   </data>
-  <data name="fightingGroup" xml:space="preserve">
-    <value>Fighting Games</value>
+  <data name="tasofroGroup" xml:space="preserve">
+    <value>Twilight Frontier Games</value>
   </data>
   <data name="mainGroup" xml:space="preserve">
     <value>Main Games</value>
   </data>
-  <data name="otherGroup" xml:space="preserve">
-    <value>Other Games</value>
+  <data name="pc98Group" xml:space="preserve">
+    <value>PC-98 Games</value>
   </data>
   <data name="AoCFShort" xml:space="preserve">
     <value>AoCF</value>
@@ -741,5 +741,8 @@ random game option:</value>
   </data>
   <data name="HBMTitle" xml:space="preserve">
     <value>Touhou 18.5: 100th Black Market</value>
+  </data>
+  <data name="spinoffGroup" xml:space="preserve">
+    <value>Spinoffs</value>
   </data>
 </root>

--- a/Touhou Launcher/Resources_jp.Designer.cs
+++ b/Touhou Launcher/Resources_jp.Designer.cs
@@ -61,7 +61,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to All Files.
+        ///   Looks up a localized string similar to すべてのファイル.
         /// </summary>
         public static string allFilter {
             get {
@@ -106,7 +106,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Auto-Close.
+        ///   Looks up a localized string similar to 自動終了.
         /// </summary>
         public static string autoClose {
             get {
@@ -115,7 +115,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Automatically close the launcher after launching a game.
+        ///   Looks up a localized string similar to ゲームを起動した後、自動的にランチャーを閉じます.
         /// </summary>
         public static string autoCloseToolTip {
             get {
@@ -124,7 +124,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 灰色画像.
+        ///   Looks up a localized string similar to バナー（白黒）.
         /// </summary>
         public static string bannerOffLabel {
             get {
@@ -133,7 +133,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Select the grey banner.
+        ///   Looks up a localized string similar to バナー（白黒）を指定する.
         /// </summary>
         public static string bannerOffSelectTitle {
             get {
@@ -142,7 +142,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Colored Banner.
+        ///   Looks up a localized string similar to バナー.
         /// </summary>
         public static string bannerOnLabel {
             get {
@@ -151,7 +151,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Select the colored banner.
+        ///   Looks up a localized string similar to バナーを指定する.
         /// </summary>
         public static string bannerOnSelectTitle {
             get {
@@ -160,7 +160,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Banner Settings.
+        ///   Looks up a localized string similar to バナーの設定.
         /// </summary>
         public static string bannerSettings {
             get {
@@ -178,7 +178,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show banner?.
+        ///   Looks up a localized string similar to バナーの表示.
         /// </summary>
         public static string bannerToolStripMenuItem {
             get {
@@ -187,7 +187,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Browse.
+        ///   Looks up a localized string similar to 参照.
         /// </summary>
         public static string browse {
             get {
@@ -196,7 +196,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Set Color.
+        ///   Looks up a localized string similar to 色を指定.
         /// </summary>
         public static string btnCustomText {
             get {
@@ -205,7 +205,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Edit Button.
+        ///   Looks up a localized string similar to 表示.
         /// </summary>
         public static string buttonToolStripMenuItem {
             get {
@@ -214,7 +214,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use custom banner.
+        ///   Looks up a localized string similar to カスタムバナーを使用.
         /// </summary>
         public static string chkCustomBanner {
             get {
@@ -223,7 +223,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use custom text color.
+        ///   Looks up a localized string similar to 指定した色を使用.
         /// </summary>
         public static string chkCustomText {
             get {
@@ -232,7 +232,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Configure Game.
+        ///   Looks up a localized string similar to 設定.
         /// </summary>
         public static string configureToolStripMenuItem {
             get {
@@ -241,7 +241,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Configure thcrap.
+        ///   Looks up a localized string similar to thcrapの設定.
         /// </summary>
         public static string crapConfigure {
             get {
@@ -250,7 +250,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to thcrap_loader Location:.
+        ///   Looks up a localized string similar to thcrap_loaderの場所：.
         /// </summary>
         public static string crapDirLabel {
             get {
@@ -259,7 +259,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to thcrap Profile:.
+        ///   Looks up a localized string similar to thcrapプロファイル:.
         /// </summary>
         public static string crapLabel {
             get {
@@ -268,7 +268,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Default.
+        ///   Looks up a localized string similar to デフォルト.
         /// </summary>
         public static string crapResetStartingRepo {
             get {
@@ -277,7 +277,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to thcrap Starting Repository:.
+        ///   Looks up a localized string similar to thcrap起動用リポジトリ:.
         /// </summary>
         public static string crapStartingRepoLabel {
             get {
@@ -286,7 +286,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ゲームを足す.
+        ///   Looks up a localized string similar to ゲームを追加.
         /// </summary>
         public static string customAdd {
             get {
@@ -295,7 +295,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete Category &apos;{0}&apos; and all of its contents?.
+        ///   Looks up a localized string similar to 「{0}」とその中にいるすべてを削除しますか？.
         /// </summary>
         public static string customCategoryDeleteConfirm {
             get {
@@ -304,7 +304,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos;を消すか？.
+        ///   Looks up a localized string similar to 「{0}」を削除しますか？.
         /// </summary>
         public static string customDeleteConfirm {
             get {
@@ -313,7 +313,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Custom Games.
+        ///   Looks up a localized string similar to 同人ゲーム.
         /// </summary>
         public static string customGames {
             get {
@@ -331,7 +331,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove Game.
+        ///   Looks up a localized string similar to ゲームを削除する.
         /// </summary>
         public static string customRemove {
             get {
@@ -376,7 +376,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Default Executable:.
+        ///   Looks up a localized string similar to デフォルトで開く:.
         /// </summary>
         public static string defaultLabel {
             get {
@@ -385,7 +385,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete Category.
+        ///   Looks up a localized string similar to 削除.
         /// </summary>
         public static string deleteCategoryToolStripMenuItem {
             get {
@@ -394,7 +394,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 消す.
+        ///   Looks up a localized string similar to 削除.
         /// </summary>
         public static string deleteToolStripMenuItem {
             get {
@@ -412,7 +412,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Description.
+        ///   Looks up a localized string similar to 説明.
         /// </summary>
         public static string descriptionColumn {
             get {
@@ -493,7 +493,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot find Appdata Folder.
+        ///   Looks up a localized string similar to Appdataフォルダが見つりません.
         /// </summary>
         public static string errorAppdataNotFound {
             get {
@@ -502,7 +502,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Please set thcrap&apos;s profile.
+        ///   Looks up a localized string similar to thcrapのプロファイルを設定してください.
         /// </summary>
         public static string errorcrapConfigNotSet {
             get {
@@ -511,7 +511,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Please set thcrap&apos;s location.
+        ///   Looks up a localized string similar to thcrapのパスを指定してください.
         /// </summary>
         public static string errorcrapNotFound {
             get {
@@ -520,7 +520,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to File could not be found.
+        ///   Looks up a localized string similar to ファイルが見つかりません.
         /// </summary>
         public static string errorFileNotFound {
             get {
@@ -529,7 +529,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot find game. Please check the path in the right click menu..
+        ///   Looks up a localized string similar to ゲームファイルが見つからない。右クリックメニューでパスを指定してください。.
         /// </summary>
         public static string errorGameNotFound {
             get {
@@ -538,7 +538,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Neko Project II&apos;s configuration ini is not valid..
+        ///   Looks up a localized string similar to Neko Project IIのコンフィグiniは有効ではありません。.
         /// </summary>
         public static string errorInvalidNP2INI {
             get {
@@ -547,7 +547,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No Category Selected.
+        ///   Looks up a localized string similar to カテゴリーが選択されていません.
         /// </summary>
         public static string errorNoCategorySelected {
             get {
@@ -556,7 +556,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Please set Neko Project 2&apos;s location.
+        ///   Looks up a localized string similar to Neko Project 2のパスを指定してください.
         /// </summary>
         public static string errorNP2NotFound {
             get {
@@ -565,7 +565,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot open file as image:
+        ///   Looks up a localized string similar to 画像ファイルではありません：
         ///.
         /// </summary>
         public static string errorOpenImage {
@@ -575,7 +575,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No Games Selected.
+        ///   Looks up a localized string similar to ゲームが選択されていません.
         /// </summary>
         public static string errorRandomListEmpty {
             get {
@@ -584,7 +584,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot find Replays folder.
+        ///   Looks up a localized string similar to replayフォルダが見つかりません.
         /// </summary>
         public static string errorReplaysNotFound {
             get {
@@ -593,7 +593,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot find vpatch.ini.
+        ///   Looks up a localized string similar to vpatch.iniが見つかりません.
         /// </summary>
         public static string errorvpatchNotFound {
             get {
@@ -602,7 +602,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Executable Files.
+        ///   Looks up a localized string similar to 実行ファイル.
         /// </summary>
         public static string executableFilter {
             get {
@@ -611,7 +611,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Game Configuration: .
+        ///   Looks up a localized string similar to ゲームの設定：.
         /// </summary>
         public static string gameConfiguration {
             get {
@@ -620,7 +620,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Game Profiles.
+        ///   Looks up a localized string similar to ゲームプロファイル.
         /// </summary>
         public static string gameGroup {
             get {
@@ -629,7 +629,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Game ID.
+        ///   Looks up a localized string similar to ゲームID.
         /// </summary>
         public static string gameIDColumn {
             get {
@@ -647,7 +647,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Select Executable.
+        ///   Looks up a localized string similar to ゲームの実行ファイルを指定する.
         /// </summary>
         public static string gameSelectTitle {
             get {
@@ -737,7 +737,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hard Disk Image Files.
+        ///   Looks up a localized string similar to HDIファイル.
         /// </summary>
         public static string hdiFilter {
             get {
@@ -746,7 +746,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Game HDI:.
+        ///   Looks up a localized string similar to HDIファイル:.
         /// </summary>
         public static string hdiLabel {
             get {
@@ -755,7 +755,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Select the game&apos;s HDI.
+        ///   Looks up a localized string similar to ゲームのHDIファイルを指定する.
         /// </summary>
         public static string hdiSelectTitle {
             get {
@@ -881,7 +881,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Image Files.
+        ///   Looks up a localized string similar to 画像ファイル.
         /// </summary>
         public static string imageFilter {
             get {
@@ -899,7 +899,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Info.
+        ///   Looks up a localized string similar to 東方ランチャーについて.
         /// </summary>
         public static string info {
             get {
@@ -926,7 +926,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 弾幕アマノジャク.
+        ///   Looks up a localized string similar to アマノジャク.
         /// </summary>
         public static string ISC {
             get {
@@ -953,7 +953,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Japanese/vpatch Executable:.
+        ///   Looks up a localized string similar to 実行ファイルの場所：.
         /// </summary>
         public static string jpLabel {
             get {
@@ -962,7 +962,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 語：.
+        ///   Looks up a localized string similar to 言語：.
         /// </summary>
         public static string langLabel {
             get {
@@ -971,7 +971,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Large Icons.
+        ///   Looks up a localized string similar to 大アイコン.
         /// </summary>
         public static string largeIconsToolStripMenuItem {
             get {
@@ -980,7 +980,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Launch.
+        ///   Looks up a localized string similar to 起動.
         /// </summary>
         public static string launch {
             get {
@@ -989,7 +989,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Launcher Settings.
+        ///   Looks up a localized string similar to 全般.
         /// </summary>
         public static string launcherSettings {
             get {
@@ -998,7 +998,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to List.
+        ///   Looks up a localized string similar to 一覧.
         /// </summary>
         public static string listToolStripMenuItem {
             get {
@@ -1061,7 +1061,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to メインゲーム.
+        ///   Looks up a localized string similar to 整数作.
         /// </summary>
         public static string mainGroup {
             get {
@@ -1070,7 +1070,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Minimize to tray.
+        ///   Looks up a localized string similar to トレイに最小化.
         /// </summary>
         public static string minimizeToTray {
             get {
@@ -1133,7 +1133,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 怪綺談.
+        ///   Looks up a localized string similar to 新規作成.
         /// </summary>
         public static string newCategoryToolStripMenuItem {
             get {
@@ -1142,7 +1142,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Neko Project II Location:.
+        ///   Looks up a localized string similar to Neko Project IIの場所：.
         /// </summary>
         public static string np2Label {
             get {
@@ -1151,7 +1151,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Select Neko Project II&apos;s executable.
+        ///   Looks up a localized string similar to Neko Project IIの実行ファイルを指定する.
         /// </summary>
         public static string np2SelectTitle {
             get {
@@ -1160,7 +1160,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Appdata Folder.
+        ///   Looks up a localized string similar to Appdataフォルダ.
         /// </summary>
         public static string openAppdata {
             get {
@@ -1169,7 +1169,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open Folder.
+        ///   Looks up a localized string similar to フォルダを開く.
         /// </summary>
         public static string openFolder {
             get {
@@ -1178,7 +1178,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open Folder.
+        ///   Looks up a localized string similar to フォルダを開く.
         /// </summary>
         public static string openFolderToolStripMenuItem {
             get {
@@ -1187,7 +1187,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open Neko Project II Folder.
+        ///   Looks up a localized string similar to Neko Project IIのフォルダを開く.
         /// </summary>
         public static string openNP2Folder {
             get {
@@ -1196,7 +1196,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open Replays Folder.
+        ///   Looks up a localized string similar to replayフォルダ.
         /// </summary>
         public static string openReplays {
             get {
@@ -1205,7 +1205,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to vpatch.iniを編集する.
+        ///   Looks up a localized string similar to vpatch.iniを編集.
         /// </summary>
         public static string openvpatch {
             get {
@@ -1214,7 +1214,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open With Applocale.
+        ///   Looks up a localized string similar to Applocaleで開く.
         /// </summary>
         public static string openWithApplocaleToolStripMenuItem {
             get {
@@ -1223,7 +1223,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Patch.
+        ///   Looks up a localized string similar to パッチ.
         /// </summary>
         public static string patchColumn {
             get {
@@ -1232,7 +1232,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Custom Profile.
+        ///   Looks up a localized string similar to カスタムプロファイル.
         /// </summary>
         public static string patchGroup {
             get {
@@ -1241,7 +1241,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Game Path.
+        ///   Looks up a localized string similar to ゲームパス.
         /// </summary>
         public static string pathColumn {
             get {
@@ -1259,7 +1259,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to PC-98 Game Settings.
+        ///   Looks up a localized string similar to PC-98版用.
         /// </summary>
         public static string pc98Settings {
             get {
@@ -1295,7 +1295,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Play Random.
+        ///   Looks up a localized string similar to ランダムでゲームを起動.
         /// </summary>
         public static string playRandomToolStripMenuItem {
             get {
@@ -1358,7 +1358,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Random.
+        ///   Looks up a localized string similar to ランダム.
         /// </summary>
         public static string Random {
             get {
@@ -1367,7 +1367,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 全部.
+        ///   Looks up a localized string similar to すべて.
         /// </summary>
         public static string randomAll {
             get {
@@ -1376,8 +1376,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Games that will be included in the
-        ///random game option:.
+        ///   Looks up a localized string similar to ランダムで起動したいゲームを選んでください.
         /// </summary>
         public static string randomLabel {
             get {
@@ -1395,7 +1394,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Random Game Settings.
+        ///   Looks up a localized string similar to ランダム起動.
         /// </summary>
         public static string randomSettings {
             get {
@@ -1404,7 +1403,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ランダムゲームを実行する.
+        ///   Looks up a localized string similar to ランダムでゲームを起動します.
         /// </summary>
         public static string RandomTitle {
             get {
@@ -1413,7 +1412,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rename Category.
+        ///   Looks up a localized string similar to 名前の変更.
         /// </summary>
         public static string renameCategoryToolStripMenuItem {
             get {
@@ -1422,7 +1421,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rename.
+        ///   Looks up a localized string similar to 名前の変更.
         /// </summary>
         public static string renameToolStripMenuItem {
             get {
@@ -1431,8 +1430,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Download &apos;{0}&apos; to:
-        ///{1}.
+        ///   Looks up a localized string similar to &apos;{1}&apos;に&apos;{0}&apos;をダウンロードします.
         /// </summary>
         public static string replayDownload {
             get {
@@ -1441,7 +1439,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Download Replay?.
+        ///   Looks up a localized string similar to リプレイをダウンロードしますか？.
         /// </summary>
         public static string replayDownloadTitle {
             get {
@@ -1450,7 +1448,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Replay Files.
+        ///   Looks up a localized string similar to リプレイファイル.
         /// </summary>
         public static string replayFilter {
             get {
@@ -1459,7 +1457,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Player replays full and Touhou 10 does not support user replays.
+        ///   Looks up a localized string similar to リプレイリストがいっぱいです。（風神録はユーザーリプレイをサポートしていません）
         ///.
         /// </summary>
         public static string replayFull {
@@ -1505,7 +1503,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Selected Patches.
+        ///   Looks up a localized string similar to 選択されたパッチ.
         /// </summary>
         public static string selectedPatches {
             get {
@@ -1532,7 +1530,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Small Icons.
+        ///   Looks up a localized string similar to 小アイコン.
         /// </summary>
         public static string smallIconsToolStripMenuItem {
             get {
@@ -1577,7 +1575,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Spinoffs.
+        ///   Looks up a localized string similar to 小数点作.
         /// </summary>
         public static string spinoffGroup {
             get {
@@ -1640,7 +1638,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 黄昏フロンティアとの共同作品.
+        ///   Looks up a localized string similar to 黄昏フロンティア作.
         /// </summary>
         public static string tasofroGroup {
             get {
@@ -1676,7 +1674,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show Text?.
+        ///   Looks up a localized string similar to タイトルの表示.
         /// </summary>
         public static string textToolStripMenuItem {
             get {
@@ -1685,7 +1683,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Profile Configuration: .
+        ///   Looks up a localized string similar to プロファイルの設定：.
         /// </summary>
         public static string thcrapTitle {
             get {
@@ -1712,7 +1710,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Title.
+        ///   Looks up a localized string similar to タイトル.
         /// </summary>
         public static string titleColumn {
             get {
@@ -1721,7 +1719,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Exit.
+        ///   Looks up a localized string similar to 終了.
         /// </summary>
         public static string trayExit {
             get {
@@ -1730,7 +1728,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open.
+        ///   Looks up a localized string similar to 表示.
         /// </summary>
         public static string trayOpen {
             get {
@@ -1739,7 +1737,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Random Game.
+        ///   Looks up a localized string similar to ランダムでゲームを起動.
         /// </summary>
         public static string trayRandom {
             get {
@@ -1856,7 +1854,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to AppLocaleで.
+        ///   Looks up a localized string similar to AppLocaleで実行.
         /// </summary>
         public static string useApplocale {
             get {
@@ -1928,7 +1926,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Windows Game Settings.
+        ///   Looks up a localized string similar to Windows版用.
         /// </summary>
         public static string windowsSettings {
             get {

--- a/Touhou Launcher/Resources_jp.Designer.cs
+++ b/Touhou Launcher/Resources_jp.Designer.cs
@@ -719,6 +719,33 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to バレットフィリア達の闇市場.
+        /// </summary>
+        public static string HBM {
+            get {
+                return ResourceManager.GetString("HBM", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to バレットフィリア.
+        /// </summary>
+        public static string HBMShort {
+            get {
+                return ResourceManager.GetString("HBMShort", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to バレットフィリア達の闇市場　〜 100th Black Market.
+        /// </summary>
+        public static string HBMTitle {
+            get {
+                return ResourceManager.GetString("HBMTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hard Disk Image Files.
         /// </summary>
         public static string hdiFilter {

--- a/Touhou Launcher/Resources_jp.Designer.cs
+++ b/Touhou Launcher/Resources_jp.Designer.cs
@@ -529,7 +529,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot find game.
+        ///   Looks up a localized string similar to Cannot find game. Please check the path in the right click menu..
         /// </summary>
         public static string errorGameNotFound {
             get {
@@ -543,6 +543,15 @@ namespace Touhou_Launcher {
         public static string errorInvalidNP2INI {
             get {
                 return ResourceManager.GetString("errorInvalidNP2INI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No Category Selected.
+        /// </summary>
+        public static string errorNoCategorySelected {
+            get {
+                return ResourceManager.GetString("errorNoCategorySelected", resourceCulture);
             }
         }
         

--- a/Touhou Launcher/Resources_jp.Designer.cs
+++ b/Touhou Launcher/Resources_jp.Designer.cs
@@ -611,15 +611,6 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 格闘ゲーム.
-        /// </summary>
-        public static string fightingGroup {
-            get {
-                return ResourceManager.GetString("fightingGroup", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Game Configuration: .
         /// </summary>
         public static string gameConfiguration {
@@ -1232,15 +1223,6 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 他のゲーム.
-        /// </summary>
-        public static string otherGroup {
-            get {
-                return ResourceManager.GetString("otherGroup", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Patch.
         /// </summary>
         public static string patchColumn {
@@ -1264,6 +1246,15 @@ namespace Touhou_Launcher {
         public static string pathColumn {
             get {
                 return ResourceManager.GetString("pathColumn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 旧作.
+        /// </summary>
+        public static string pc98Group {
+            get {
+                return ResourceManager.GetString("pc98Group", resourceCulture);
             }
         }
         
@@ -1586,6 +1577,15 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Spinoffs.
+        /// </summary>
+        public static string spinoffGroup {
+            get {
+                return ResourceManager.GetString("spinoffGroup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to 東方文花帖.
         /// </summary>
         public static string StB {
@@ -1636,6 +1636,15 @@ namespace Touhou_Launcher {
         public static string SWRTitle {
             get {
                 return ResourceManager.GetString("SWRTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 黄昏フロンティアとの共同作品.
+        /// </summary>
+        public static string tasofroGroup {
+            get {
+                return ResourceManager.GetString("tasofroGroup", resourceCulture);
             }
         }
         

--- a/Touhou Launcher/Resources_jp.Designer.cs
+++ b/Touhou Launcher/Resources_jp.Designer.cs
@@ -683,6 +683,33 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 東方剛欲異聞.
+        /// </summary>
+        public static string GI {
+            get {
+                return ResourceManager.GetString("GI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 剛欲異聞.
+        /// </summary>
+        public static string GIShort {
+            get {
+                return ResourceManager.GetString("GIShort", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 東方剛欲異聞　～ 水没した沈愁地獄.
+        /// </summary>
+        public static string GITitle {
+            get {
+                return ResourceManager.GetString("GITitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hard Disk Image Files.
         /// </summary>
         public static string hdiFilter {

--- a/Touhou Launcher/Resources_jp.resx
+++ b/Touhou Launcher/Resources_jp.resx
@@ -535,7 +535,7 @@
   <data name="errorvpatchNotFound" xml:space="preserve">
     <value>vpatch.iniが見つかりません</value>
   </data>
-  <data name="exzecutableFilter" xml:space="preserve">
+  <data name="executableFilter" xml:space="preserve">
     <value>実行ファイル</value>
   </data>
   <data name="gameSelectTitle" xml:space="preserve">

--- a/Touhou Launcher/Resources_jp.resx
+++ b/Touhou Launcher/Resources_jp.resx
@@ -733,4 +733,13 @@ random game option:</value>
   <data name="errorNoCategorySelected" xml:space="preserve">
     <value>No Category Selected</value>
   </data>
+  <data name="HBM" xml:space="preserve">
+    <value>バレットフィリア達の闇市場</value>
+  </data>
+  <data name="HBMShort" xml:space="preserve">
+    <value>バレットフィリア</value>
+  </data>
+  <data name="HBMTitle" xml:space="preserve">
+    <value>バレットフィリア達の闇市場　〜 100th Black Market</value>
+  </data>
 </root>

--- a/Touhou Launcher/Resources_jp.resx
+++ b/Touhou Launcher/Resources_jp.resx
@@ -288,14 +288,14 @@
   <data name="Title" xml:space="preserve">
     <value>東方ランチャー</value>
   </data>
-  <data name="fightingGroup" xml:space="preserve">
-    <value>格闘ゲーム</value>
+  <data name="tasofroGroup" xml:space="preserve">
+    <value>黄昏フロンティアとの共同作品</value>
   </data>
   <data name="mainGroup" xml:space="preserve">
     <value>メインゲーム</value>
   </data>
-  <data name="otherGroup" xml:space="preserve">
-    <value>他のゲーム</value>
+  <data name="pc98Group" xml:space="preserve">
+    <value>旧作</value>
   </data>
   <data name="AoCFShort" xml:space="preserve">
     <value>憑依華</value>
@@ -741,5 +741,8 @@ random game option:</value>
   </data>
   <data name="HBMTitle" xml:space="preserve">
     <value>バレットフィリア達の闇市場　〜 100th Black Market</value>
+  </data>
+  <data name="spinoffGroup" xml:space="preserve">
+    <value>Spinoffs</value>
   </data>
 </root>

--- a/Touhou Launcher/Resources_jp.resx
+++ b/Touhou Launcher/Resources_jp.resx
@@ -178,7 +178,7 @@
     <value>東方永夜抄　～ Imperishable Night</value>
   </data>
   <data name="ISC" xml:space="preserve">
-    <value>弾幕アマノジャク</value>
+    <value>アマノジャク</value>
   </data>
   <data name="ISCTitle" xml:space="preserve">
     <value>弾幕アマノジャク　～ Impossible Spell Card</value>
@@ -280,19 +280,19 @@
     <value>秘封ナイトメアダイアリー　〜 Violet Detector</value>
   </data>
   <data name="Random" xml:space="preserve">
-    <value>Random</value>
+    <value>ランダム</value>
   </data>
   <data name="RandomTitle" xml:space="preserve">
-    <value>ランダムゲームを実行する</value>
+    <value>ランダムでゲームを起動します</value>
   </data>
   <data name="Title" xml:space="preserve">
     <value>東方ランチャー</value>
   </data>
   <data name="tasofroGroup" xml:space="preserve">
-    <value>黄昏フロンティアとの共同作品</value>
+    <value>黄昏フロンティア作</value>
   </data>
   <data name="mainGroup" xml:space="preserve">
-    <value>メインゲーム</value>
+    <value>整数作</value>
   </data>
   <data name="pc98Group" xml:space="preserve">
     <value>旧作</value>
@@ -300,26 +300,56 @@
   <data name="AoCFShort" xml:space="preserve">
     <value>憑依華</value>
   </data>
+  <data name="autoClose" xml:space="preserve">
+    <value>自動終了</value>
+  </data>
+  <data name="autoCloseToolTip" xml:space="preserve">
+    <value>ゲームを起動した後、自動的にランチャーを閉じます</value>
+  </data>
+  <data name="bannerOffLabel" xml:space="preserve">
+    <value>バナー（白黒）</value>
+  </data>
+  <data name="bannerOnLabel" xml:space="preserve">
+    <value>バナー</value>
+  </data>
+  <data name="bannerSettings" xml:space="preserve">
+    <value>バナーの設定</value>
+  </data>
   <data name="browse" xml:space="preserve">
-    <value>Browse</value>
+    <value>参照</value>
+  </data>
+  <data name="chkCustomBanner" xml:space="preserve">
+    <value>カスタムバナーを使用</value>
   </data>
   <data name="configureToolStripMenuItem" xml:space="preserve">
-    <value>Configure Game</value>
+    <value>設定</value>
+  </data>
+  <data name="crapLabel" xml:space="preserve">
+    <value>thcrapプロファイル:</value>
   </data>
   <data name="customAdd" xml:space="preserve">
-    <value>ゲームを足す</value>
+    <value>ゲームを追加</value>
   </data>
   <data name="customGames" xml:space="preserve">
-    <value>Custom Games</value>
+    <value>同人ゲーム</value>
+  </data>
+  <data name="customLabel" xml:space="preserve">
+    <value>Custom.exe:</value>
   </data>
   <data name="DDCShort" xml:space="preserve">
     <value>輝針城</value>
   </data>
+  <data name="defaultLabel" xml:space="preserve">
+    <value>デフォルトで開く:</value>
+  </data>
   <data name="deleteCategoryToolStripMenuItem" xml:space="preserve">
-    <value>Delete Category</value>
+    <value>削除</value>
   </data>
   <data name="DSShort" xml:space="preserve">
     <value>ダブルスポイラー</value>
+  </data>
+  <data name="enLabel" xml:space="preserve">
+    <value>English Executable:</value>
   </data>
   <data name="EoSDShort" xml:space="preserve">
     <value>紅魔郷</value>
@@ -329,6 +359,9 @@
   </data>
   <data name="GFWShort" xml:space="preserve">
     <value>妖精大戦争</value>
+  </data>
+  <data name="hdiLabel" xml:space="preserve">
+    <value>HDIファイル:</value>
   </data>
   <data name="HMShort" xml:space="preserve">
     <value>心綺楼</value>
@@ -343,7 +376,7 @@
     <value>萃夢想</value>
   </data>
   <data name="info" xml:space="preserve">
-    <value>Info</value>
+    <value>東方ランチャーについて</value>
   </data>
   <data name="INShort" xml:space="preserve">
     <value>永夜抄</value>
@@ -351,8 +384,17 @@
   <data name="ISCShort" xml:space="preserve">
     <value>アマノジャク</value>
   </data>
+  <data name="jpLabel" xml:space="preserve">
+    <value>実行ファイルの場所：</value>
+  </data>
+  <data name="langLabel" xml:space="preserve">
+    <value>言語：</value>
+  </data>
+  <data name="launch" xml:space="preserve">
+    <value>起動</value>
+  </data>
   <data name="launcherSettings" xml:space="preserve">
-    <value>Launcher Settings</value>
+    <value>全般</value>
   </data>
   <data name="LLSShort" xml:space="preserve">
     <value>幻想郷</value>
@@ -367,7 +409,25 @@
     <value>怪綺談</value>
   </data>
   <data name="newCategoryToolStripMenuItem" xml:space="preserve">
-    <value>怪綺談</value>
+    <value>新規作成</value>
+  </data>
+  <data name="np2Label" xml:space="preserve">
+    <value>Neko Project IIの場所：</value>
+  </data>
+  <data name="openFolder" xml:space="preserve">
+    <value>フォルダを開く</value>
+  </data>
+  <data name="openNP2Folder" xml:space="preserve">
+    <value>Neko Project IIのフォルダを開く</value>
+  </data>
+  <data name="openReplays" xml:space="preserve">
+    <value>replayフォルダ</value>
+  </data>
+  <data name="openvpatch" xml:space="preserve">
+    <value>vpatch.iniを編集</value>
+  </data>
+  <data name="pc98Settings" xml:space="preserve">
+    <value>PC-98版用</value>
   </data>
   <data name="PCBShort" xml:space="preserve">
     <value>妖々夢</value>
@@ -379,16 +439,19 @@
     <value>花映塚</value>
   </data>
   <data name="randomAll" xml:space="preserve">
-    <value>全部</value>
+    <value>すべて</value>
+  </data>
+  <data name="randomLabel" xml:space="preserve">
+    <value>ランダムで起動したいゲームを選んでください</value>
   </data>
   <data name="randomNone" xml:space="preserve">
     <value>なし</value>
   </data>
   <data name="randomSettings" xml:space="preserve">
-    <value>Random Game Settings</value>
+    <value>ランダム起動</value>
   </data>
   <data name="renameCategoryToolStripMenuItem" xml:space="preserve">
-    <value>Rename Category</value>
+    <value>名前の変更</value>
   </data>
   <data name="replays" xml:space="preserve">
     <value>リプレイ</value>
@@ -420,96 +483,32 @@
   <data name="UoNLShort" xml:space="preserve">
     <value>非想天則</value>
   </data>
+  <data name="useApplocale" xml:space="preserve">
+    <value>AppLocaleで実行</value>
+  </data>
   <data name="VDShort" xml:space="preserve">
     <value>ナイトメアダイアリー</value>
   </data>
-  <data name="launch" xml:space="preserve">
-    <value>Launch</value>
-  </data>
-  <data name="autoClose" xml:space="preserve">
-    <value>Auto-Close</value>
-  </data>
-  <data name="autoCloseToolTip" xml:space="preserve">
-    <value>Automatically close the launcher after launching a game</value>
-  </data>
-  <data name="bannerOffLabel" xml:space="preserve">
-    <value>灰色画像</value>
-  </data>
-  <data name="bannerOnLabel" xml:space="preserve">
-    <value>Colored Banner</value>
-  </data>
-  <data name="bannerSettings" xml:space="preserve">
-    <value>Banner Settings</value>
-  </data>
-  <data name="chkCustomBanner" xml:space="preserve">
-    <value>Use custom banner</value>
-  </data>
-  <data name="crapLabel" xml:space="preserve">
-    <value>thcrap Profile:</value>
-  </data>
-  <data name="customLabel" xml:space="preserve">
-    <value>Custom.exe:</value>
-  </data>
-  <data name="defaultLabel" xml:space="preserve">
-    <value>Default Executable:</value>
-  </data>
-  <data name="enLabel" xml:space="preserve">
-    <value>English Executable:</value>
-  </data>
-  <data name="hdiLabel" xml:space="preserve">
-    <value>Game HDI:</value>
-  </data>
-  <data name="jpLabel" xml:space="preserve">
-    <value>Japanese/vpatch Executable:</value>
-  </data>
-  <data name="langLabel" xml:space="preserve">
-    <value>語：</value>
-  </data>
-  <data name="np2Label" xml:space="preserve">
-    <value>Neko Project II Location:</value>
-  </data>
-  <data name="openFolder" xml:space="preserve">
-    <value>Open Folder</value>
-  </data>
-  <data name="openAppdata" xml:space="preserve">
-    <value>Appdata Folder</value>
-  </data>
-  <data name="openReplays" xml:space="preserve">
-    <value>Open Replays Folder</value>
-  </data>
-  <data name="openvpatch" xml:space="preserve">
-    <value>vpatch.iniを編集する</value>
-  </data>
-  <data name="pc98Settings" xml:space="preserve">
-    <value>PC-98 Game Settings</value>
-  </data>
-  <data name="randomLabel" xml:space="preserve">
-    <value>Games that will be included in the
-random game option:</value>
-  </data>
-  <data name="useApplocale" xml:space="preserve">
-    <value>AppLocaleで</value>
-  </data>
   <data name="windowsSettings" xml:space="preserve">
-    <value>Windows Game Settings</value>
-  </data>
-  <data name="defaultExec" xml:space="preserve">
-    <value>日本語/vpatch.ini, 英語 (non-THCRAP), Custom.exe, thcrap</value>
+    <value>Windows版用</value>
   </data>
   <data name="allFilter" xml:space="preserve">
-    <value>All Files</value>
+    <value>すべてのファイル</value>
   </data>
   <data name="ascendingToolStripMenuItem" xml:space="preserve">
     <value>昇順</value>
   </data>
   <data name="bannerOffSelectTitle" xml:space="preserve">
-    <value>Select the grey banner</value>
+    <value>バナー（白黒）を指定する</value>
   </data>
   <data name="bannerOnSelectTitle" xml:space="preserve">
-    <value>Select the colored banner</value>
+    <value>バナーを指定する</value>
+  </data>
+  <data name="defaultExec" xml:space="preserve">
+    <value>日本語/vpatch.ini, 英語 (non-THCRAP), Custom.exe, thcrap</value>
   </data>
   <data name="deleteToolStripMenuItem" xml:space="preserve">
-    <value>消す</value>
+    <value>削除</value>
   </data>
   <data name="descendingToolStripMenuItem" xml:space="preserve">
     <value>降順</value>
@@ -518,65 +517,65 @@ random game option:</value>
     <value>詳細</value>
   </data>
   <data name="errorAppdataNotFound" xml:space="preserve">
-    <value>Cannot find Appdata Folder</value>
+    <value>Appdataフォルダが見つりません</value>
   </data>
   <data name="errorFileNotFound" xml:space="preserve">
-    <value>File could not be found</value>
+    <value>ファイルが見つかりません</value>
   </data>
   <data name="errorNP2NotFound" xml:space="preserve">
-    <value>Please set Neko Project 2's location</value>
+    <value>Neko Project 2のパスを指定してください</value>
   </data>
   <data name="errorOpenImage" xml:space="preserve">
-    <value>Cannot open file as image:
+    <value>画像ファイルではありません：
 </value>
   </data>
   <data name="errorReplaysNotFound" xml:space="preserve">
-    <value>Cannot find Replays folder</value>
+    <value>replayフォルダが見つかりません</value>
   </data>
   <data name="errorvpatchNotFound" xml:space="preserve">
-    <value>Cannot find vpatch.ini</value>
+    <value>vpatch.iniが見つかりません</value>
   </data>
-  <data name="executableFilter" xml:space="preserve">
-    <value>Executable Files</value>
+  <data name="exzecutableFilter" xml:space="preserve">
+    <value>実行ファイル</value>
   </data>
   <data name="gameSelectTitle" xml:space="preserve">
-    <value>Select Executable</value>
+    <value>ゲームの実行ファイルを指定する</value>
   </data>
   <data name="hdiFilter" xml:space="preserve">
-    <value>Hard Disk Image Files</value>
+    <value>HDIファイル</value>
   </data>
   <data name="hdiSelectTitle" xml:space="preserve">
-    <value>Select the game's HDI</value>
+    <value>ゲームのHDIファイルを指定する</value>
   </data>
   <data name="imageFilter" xml:space="preserve">
-    <value>Image Files</value>
+    <value>画像ファイル</value>
   </data>
   <data name="largeIconsToolStripMenuItem" xml:space="preserve">
-    <value>Large Icons</value>
+    <value>大アイコン</value>
   </data>
   <data name="listToolStripMenuItem" xml:space="preserve">
-    <value>List</value>
+    <value>一覧</value>
   </data>
   <data name="np2SelectTitle" xml:space="preserve">
-    <value>Select Neko Project II's executable</value>
+    <value>Neko Project IIの実行ファイルを指定する</value>
+  </data>
+  <data name="openAppdata" xml:space="preserve">
+    <value>Appdataフォルダ</value>
   </data>
   <data name="openFolderToolStripMenuItem" xml:space="preserve">
-    <value>Open Folder</value>
-  </data>
-  <data name="openNP2Folder" xml:space="preserve">
-    <value>Open Neko Project II Folder</value>
+    <value>フォルダを開く</value>
   </data>
   <data name="openWithApplocaleToolStripMenuItem" xml:space="preserve">
-    <value>Open With Applocale</value>
+    <value>Applocaleで開く</value>
   </data>
   <data name="playRandomToolStripMenuItem" xml:space="preserve">
-    <value>Play Random</value>
+    <value>ランダムでゲームを起動</value>
   </data>
   <data name="renameToolStripMenuItem" xml:space="preserve">
-    <value>Rename</value>
+    <value>名前の変更</value>
   </data>
   <data name="smallIconsToolStripMenuItem" xml:space="preserve">
-    <value>Small Icons</value>
+    <value>小アイコン</value>
   </data>
   <data name="sortToolStripMenuItem" xml:space="preserve">
     <value>並べ替え</value>
@@ -588,120 +587,119 @@ random game option:</value>
     <value>表示</value>
   </data>
   <data name="errorInvalidNP2INI" xml:space="preserve">
-    <value>Neko Project II's configuration ini is not valid.</value>
+    <value>Neko Project IIのコンフィグiniは有効ではありません。</value>
   </data>
   <data name="errorGameNotFound" xml:space="preserve">
-    <value>Cannot find game. Please check the path in the right click menu.</value>
+    <value>ゲームファイルが見つからない。右クリックメニューでパスを指定してください。</value>
   </data>
   <data name="replayFilter" xml:space="preserve">
-    <value>Replay Files</value>
+    <value>リプレイファイル</value>
   </data>
   <data name="replayDownload" xml:space="preserve">
-    <value>Download '{0}' to:
-{1}</value>
+    <value>'{1}'に'{0}'をダウンロードします</value>
   </data>
   <data name="replayFull" xml:space="preserve">
-    <value>Player replays full and Touhou 10 does not support user replays.
+    <value>リプレイリストがいっぱいです。（風神録はユーザーリプレイをサポートしていません）
 </value>
   </data>
   <data name="gameConfiguration" xml:space="preserve">
-    <value>Game Configuration: </value>
+    <value>ゲームの設定：</value>
   </data>
   <data name="minimizeToTray" xml:space="preserve">
-    <value>Minimize to tray</value>
+    <value>トレイに最小化</value>
   </data>
   <data name="showTray" xml:space="preserve">
     <value>トレイアイコンを常に表示する</value>
   </data>
   <data name="customCategoryDeleteConfirm" xml:space="preserve">
-    <value>Delete Category '{0}' and all of its contents?</value>
+    <value>「{0}」とその中にいるすべてを削除しますか？</value>
   </data>
   <data name="customDeleteConfirm" xml:space="preserve">
-    <value>'{0}'を消すか？</value>
+    <value>「{0}」を削除しますか？</value>
   </data>
   <data name="errorcrapNotFound" xml:space="preserve">
-    <value>Please set thcrap's location</value>
+    <value>thcrapのパスを指定してください</value>
   </data>
   <data name="crapConfigure" xml:space="preserve">
-    <value>Configure thcrap</value>
+    <value>thcrapの設定</value>
   </data>
   <data name="crapDirLabel" xml:space="preserve">
-    <value>thcrap_loader Location:</value>
+    <value>thcrap_loaderの場所：</value>
   </data>
   <data name="errorcrapConfigNotSet" xml:space="preserve">
-    <value>Please set thcrap's profile</value>
+    <value>thcrapのプロファイルを設定してください</value>
   </data>
   <data name="errorRandomListEmpty" xml:space="preserve">
-    <value>No Games Selected</value>
+    <value>ゲームが選択されていません</value>
   </data>
   <data name="replayDownloadTitle" xml:space="preserve">
-    <value>Download Replay?</value>
+    <value>リプレイをダウンロードしますか？</value>
   </data>
   <data name="trayExit" xml:space="preserve">
-    <value>Exit</value>
+    <value>終了</value>
   </data>
   <data name="trayOpen" xml:space="preserve">
-    <value>Open</value>
+    <value>表示</value>
   </data>
   <data name="trayRandom" xml:space="preserve">
-    <value>Random Game</value>
+    <value>ランダムでゲームを起動</value>
   </data>
   <data name="customRemove" xml:space="preserve">
-    <value>Remove Game</value>
+    <value>ゲームを削除する</value>
   </data>
   <data name="descriptionColumn" xml:space="preserve">
-    <value>Description</value>
+    <value>説明</value>
   </data>
   <data name="gameGroup" xml:space="preserve">
-    <value>Game Profiles</value>
+    <value>ゲームプロファイル</value>
   </data>
   <data name="gameIDColumn" xml:space="preserve">
-    <value>Game ID</value>
+    <value>ゲームID</value>
   </data>
   <data name="idColumn" xml:space="preserve">
     <value>ID</value>
   </data>
   <data name="patchColumn" xml:space="preserve">
-    <value>Patch</value>
+    <value>パッチ</value>
   </data>
   <data name="patchGroup" xml:space="preserve">
-    <value>Custom Profile</value>
+    <value>カスタムプロファイル</value>
   </data>
   <data name="pathColumn" xml:space="preserve">
-    <value>Game Path</value>
+    <value>ゲームパス</value>
   </data>
   <data name="thcrapTitle" xml:space="preserve">
-    <value>Profile Configuration: </value>
+    <value>プロファイルの設定：</value>
   </data>
   <data name="titleColumn" xml:space="preserve">
-    <value>Title</value>
+    <value>タイトル</value>
   </data>
   <data name="crapResetStartingRepo" xml:space="preserve">
-    <value>Default</value>
+    <value>デフォルト</value>
   </data>
   <data name="crapStartingRepoLabel" xml:space="preserve">
-    <value>thcrap Starting Repository:</value>
+    <value>thcrap起動用リポジトリ:</value>
   </data>
   <data name="bannerSize" xml:space="preserve">
     <value>* 120 x 44</value>
   </data>
   <data name="btnCustomText" xml:space="preserve">
-    <value>Set Color</value>
+    <value>色を指定</value>
   </data>
   <data name="chkCustomText" xml:space="preserve">
-    <value>Use custom text color</value>
+    <value>指定した色を使用</value>
   </data>
   <data name="bannerToolStripMenuItem" xml:space="preserve">
-    <value>Show banner?</value>
+    <value>バナーの表示</value>
   </data>
   <data name="buttonToolStripMenuItem" xml:space="preserve">
-    <value>Edit Button</value>
+    <value>表示</value>
   </data>
   <data name="textToolStripMenuItem" xml:space="preserve">
-    <value>Show Text?</value>
+    <value>タイトルの表示</value>
   </data>
   <data name="selectedPatches" xml:space="preserve">
-    <value>Selected Patches</value>
+    <value>選択されたパッチ</value>
   </data>
   <data name="WBaWC" xml:space="preserve">
     <value>東方鬼形獣</value>
@@ -731,7 +729,7 @@ random game option:</value>
     <value>東方剛欲異聞　～ 水没した沈愁地獄</value>
   </data>
   <data name="errorNoCategorySelected" xml:space="preserve">
-    <value>No Category Selected</value>
+    <value>カテゴリーが選択されていません</value>
   </data>
   <data name="HBM" xml:space="preserve">
     <value>バレットフィリア達の闇市場</value>
@@ -743,6 +741,6 @@ random game option:</value>
     <value>バレットフィリア達の闇市場　〜 100th Black Market</value>
   </data>
   <data name="spinoffGroup" xml:space="preserve">
-    <value>Spinoffs</value>
+    <value>小数点作</value>
   </data>
 </root>

--- a/Touhou Launcher/Resources_jp.resx
+++ b/Touhou Launcher/Resources_jp.resx
@@ -591,7 +591,7 @@ random game option:</value>
     <value>Neko Project II's configuration ini is not valid.</value>
   </data>
   <data name="errorGameNotFound" xml:space="preserve">
-    <value>Cannot find game</value>
+    <value>Cannot find game. Please check the path in the right click menu.</value>
   </data>
   <data name="replayFilter" xml:space="preserve">
     <value>Replay Files</value>
@@ -729,5 +729,8 @@ random game option:</value>
   </data>
   <data name="GITitle" xml:space="preserve">
     <value>東方剛欲異聞　～ 水没した沈愁地獄</value>
+  </data>
+  <data name="errorNoCategorySelected" xml:space="preserve">
+    <value>No Category Selected</value>
   </data>
 </root>

--- a/Touhou Launcher/Resources_jp.resx
+++ b/Touhou Launcher/Resources_jp.resx
@@ -721,4 +721,13 @@ random game option:</value>
   <data name="UMTitle" xml:space="preserve">
     <value>東方虹龍洞 ～ Unconnected Marketeers</value>
   </data>
+  <data name="GI" xml:space="preserve">
+    <value>東方剛欲異聞</value>
+  </data>
+  <data name="GIShort" xml:space="preserve">
+    <value>剛欲異聞</value>
+  </data>
+  <data name="GITitle" xml:space="preserve">
+    <value>東方剛欲異聞　～ 水没した沈愁地獄</value>
+  </data>
 </root>

--- a/Touhou Launcher/Resources_ru.Designer.cs
+++ b/Touhou Launcher/Resources_ru.Designer.cs
@@ -610,15 +610,6 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Файтинги.
-        /// </summary>
-        public static string fightingGroup {
-            get {
-                return ResourceManager.GetString("fightingGroup", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Настройка игры: .
         /// </summary>
         public static string gameConfiguration {
@@ -1231,15 +1222,6 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Ответвления.
-        /// </summary>
-        public static string otherGroup {
-            get {
-                return ResourceManager.GetString("otherGroup", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Патч.
         /// </summary>
         public static string patchColumn {
@@ -1263,6 +1245,15 @@ namespace Touhou_Launcher {
         public static string pathColumn {
             get {
                 return ResourceManager.GetString("pathColumn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Игры PC-98.
+        /// </summary>
+        public static string pc98Group {
+            get {
+                return ResourceManager.GetString("pc98Group", resourceCulture);
             }
         }
         
@@ -1584,6 +1575,15 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Спиноффы.
+        /// </summary>
+        public static string spinoffGroup {
+            get {
+                return ResourceManager.GetString("spinoffGroup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Shoot the Bullet.
         /// </summary>
         public static string StB {
@@ -1634,6 +1634,15 @@ namespace Touhou_Launcher {
         public static string SWRTitle {
             get {
                 return ResourceManager.GetString("SWRTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Игры от Tasogare Frontier.
+        /// </summary>
+        public static string tasofroGroup {
+            get {
+                return ResourceManager.GetString("tasofroGroup", resourceCulture);
             }
         }
         

--- a/Touhou Launcher/Resources_ru.Designer.cs
+++ b/Touhou Launcher/Resources_ru.Designer.cs
@@ -682,6 +682,33 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Gouyoku Ibun.
+        /// </summary>
+        public static string GI {
+            get {
+                return ResourceManager.GetString("GI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to GI.
+        /// </summary>
+        public static string GIShort {
+            get {
+                return ResourceManager.GetString("GIShort", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Touhou 17.5: Gouyoku Ibun.
+        /// </summary>
+        public static string GITitle {
+            get {
+                return ResourceManager.GetString("GITitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Файлы образов жесткого диска.
         /// </summary>
         public static string hdiFilter {

--- a/Touhou Launcher/Resources_ru.Designer.cs
+++ b/Touhou Launcher/Resources_ru.Designer.cs
@@ -529,7 +529,7 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Игра не найдена.
+        ///   Looks up a localized string similar to Игра не найдена. Please check the path in the right click menu..
         /// </summary>
         public static string errorGameNotFound {
             get {
@@ -543,6 +543,15 @@ namespace Touhou_Launcher {
         public static string errorInvalidNP2INI {
             get {
                 return ResourceManager.GetString("errorInvalidNP2INI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Не выбрана ни одна категория.
+        /// </summary>
+        public static string errorNoCategorySelected {
+            get {
+                return ResourceManager.GetString("errorNoCategorySelected", resourceCulture);
             }
         }
         

--- a/Touhou Launcher/Resources_ru.Designer.cs
+++ b/Touhou Launcher/Resources_ru.Designer.cs
@@ -718,6 +718,33 @@ namespace Touhou_Launcher {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 100th Black Market.
+        /// </summary>
+        public static string HBM {
+            get {
+                return ResourceManager.GetString("HBM", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 100BM.
+        /// </summary>
+        public static string HBMShort {
+            get {
+                return ResourceManager.GetString("HBMShort", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Touhou 18.5: 100th Black Market.
+        /// </summary>
+        public static string HBMTitle {
+            get {
+                return ResourceManager.GetString("HBMTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Файлы образов жесткого диска.
         /// </summary>
         public static string hdiFilter {

--- a/Touhou Launcher/Resources_ru.resx
+++ b/Touhou Launcher/Resources_ru.resx
@@ -731,4 +731,13 @@
   <data name="errorNoCategorySelected" xml:space="preserve">
     <value>Не выбрана ни одна категория</value>
   </data>
+  <data name="HBM" xml:space="preserve">
+    <value>100th Black Market</value>
+  </data>
+  <data name="HBMShort" xml:space="preserve">
+    <value>100BM</value>
+  </data>
+  <data name="HBMTitle" xml:space="preserve">
+    <value>Touhou 18.5: 100th Black Market</value>
+  </data>
 </root>

--- a/Touhou Launcher/Resources_ru.resx
+++ b/Touhou Launcher/Resources_ru.resx
@@ -589,7 +589,7 @@
     <value>Файлы "ini" Neko Project II недействителен</value>
   </data>
   <data name="errorGameNotFound" xml:space="preserve">
-    <value>Игра не найдена</value>
+    <value>Игра не найдена. Please check the path in the right click menu.</value>
   </data>
   <data name="replayFilter" xml:space="preserve">
     <value>Файл повтров</value>
@@ -727,5 +727,8 @@
   </data>
   <data name="GITitle" xml:space="preserve">
     <value>Touhou 17.5: Gouyoku Ibun</value>
+  </data>
+  <data name="errorNoCategorySelected" xml:space="preserve">
+    <value>Не выбрана ни одна категория</value>
   </data>
 </root>

--- a/Touhou Launcher/Resources_ru.resx
+++ b/Touhou Launcher/Resources_ru.resx
@@ -719,4 +719,13 @@
   <data name="UMTitle" xml:space="preserve">
     <value>Touhou 18: Unconnected Marketeers</value>
   </data>
+  <data name="GI" xml:space="preserve">
+    <value>Gouyoku Ibun</value>
+  </data>
+  <data name="GIShort" xml:space="preserve">
+    <value>GI</value>
+  </data>
+  <data name="GITitle" xml:space="preserve">
+    <value>Touhou 17.5: Gouyoku Ibun</value>
+  </data>
 </root>

--- a/Touhou Launcher/Resources_ru.resx
+++ b/Touhou Launcher/Resources_ru.resx
@@ -288,14 +288,14 @@
   <data name="Title" xml:space="preserve">
     <value>Touhou Launcher</value>
   </data>
-  <data name="fightingGroup" xml:space="preserve">
-    <value>Файтинги</value>
+  <data name="tasofroGroup" xml:space="preserve">
+    <value>Игры от Tasogare Frontier</value>
   </data>
   <data name="mainGroup" xml:space="preserve">
     <value>Основные игры</value>
   </data>
-  <data name="otherGroup" xml:space="preserve">
-    <value>Ответвления</value>
+  <data name="pc98Group" xml:space="preserve">
+    <value>Игры PC-98</value>
   </data>
   <data name="AoCFShort" xml:space="preserve">
     <value>AoCF</value>
@@ -739,5 +739,8 @@
   </data>
   <data name="HBMTitle" xml:space="preserve">
     <value>Touhou 18.5: 100th Black Market</value>
+  </data>
+  <data name="spinoffGroup" xml:space="preserve">
+    <value>Спиноффы</value>
   </data>
 </root>

--- a/Touhou Launcher/Touhou Launcher.csproj
+++ b/Touhou Launcher/Touhou Launcher.csproj
@@ -115,10 +115,12 @@
     <EmbeddedResource Include="Resources_jp.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources_jp.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Resources_ru.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources_ru.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="thcrap.resx">
       <DependentUpon>thcrap.cs</DependentUpon>

--- a/Touhou Launcher/Touhou Launcher.csproj
+++ b/Touhou Launcher/Touhou Launcher.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Touhou_Launcher</RootNamespace>
     <AssemblyName>Touhou Launcher</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>true</UseVSHostingProcess>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,6 +33,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>thicon.ico</ApplicationIcon>
@@ -121,6 +123,7 @@
     <EmbeddedResource Include="thcrap.resx">
       <DependentUpon>thcrap.cs</DependentUpon>
     </EmbeddedResource>
+    <None Include="app.config" />
     <None Include="Properties\Settings.settings">
       <Generator>PublicSettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/Touhou Launcher/app.config
+++ b/Touhou Launcher/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/Touhou Launcher/thcrap.cs
+++ b/Touhou Launcher/thcrap.cs
@@ -40,6 +40,7 @@ namespace Touhou_Launcher
         ConfigForm cfgForm;
         string gamejs;
         Dictionary<string, repoData> repos = new Dictionary<string, repoData>();
+        List<string> checkedRepos = new List<string>();
         List<string> patchStates = new List<string>();
         Dictionary<string, string> games = new Dictionary<string, string>();
 
@@ -112,10 +113,14 @@ namespace Touhou_Launcher
 
         private void searchRepo(string address, bool child = false)
         {
-            WebClient wc = new WebClient();
-            wc.Encoding = Encoding.UTF8;
-            wc.DownloadStringCompleted += onJsonGet;
-            wc.DownloadStringAsync(new Uri(address + "/repo.js"), new string[] { address, child.ToString() });
+            if (!checkedRepos.Contains(address))
+            {
+                checkedRepos.Add(address);
+                WebClient wc = new WebClient();
+                wc.Encoding = Encoding.UTF8;
+                wc.DownloadStringCompleted += onJsonGet;
+                wc.DownloadStringAsync(new Uri(address + "/repo.js"), new string[] { address, child.ToString() });
+            }
         }
 
         private void onJsonGet(object sender, DownloadStringCompletedEventArgs e)


### PR DESCRIPTION
Touhou 18.5 support, category rearrangement, and Japanese translation.

Added: Touhou 18.5 support.
Added: Complete Japanese translation. (Courtesy of HoengSaan)
Added: Error when adding custom game without a category.
Added: Queue for fetching repos so servers aren't overloaded. Lowers refresh speed.
Changed: Rearranged the game categories: Separated the PC-98 games into their own category and renamed the fighting category to games by Twilight Frontier.
Changed: Moved Gouyoku Ibun to the Twilight Frontier category.
Changed: Made instructions more clear when launching a game that isn't set up. (Russian translation pending)
Changed: Updated .Net Framework target to 4.8
Changed: Simplified repo search to use tasks.
Changed: Changed default repo to the official server on the Touhou Patch Center.
Removed: Upwards repository crawl.